### PR TITLE
Add dsh-reverse-skill (85-skill reverse-engineering pack) to the list

### DIFF
--- a/catalog/plugins/dhicoc--dsh-reverse-skill.json
+++ b/catalog/plugins/dhicoc--dsh-reverse-skill.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "dhicoc/dsh-reverse-skill",
+  "name": "dsh-reverse-skill",
+  "repository": "https://github.com/dhicoc/dsh-reverse-skill",
+  "category": "skill",
+  "description": {
+    "en": "A DeepSeek Harness Cordis plugin that registers 85 reverse-engineering, authorized penetration-testing, and security-research skills.",
+    "zh": "一个为 DeepSeek Harness 注册 85 个逆向工程、授权渗透测试与安全研究技能的 Cordis 插件。"
+  },
+  "added": "2026-08-15"
+}

--- a/catalog/plugins/dhicoc--dsh-reverse-skill.json
+++ b/catalog/plugins/dhicoc--dsh-reverse-skill.json
@@ -8,5 +8,5 @@
     "en": "A DeepSeek Harness Cordis plugin that registers 85 reverse-engineering, authorized penetration-testing, and security-research skills.",
     "zh": "一个为 DeepSeek Harness 注册 85 个逆向工程、授权渗透测试与安全研究技能的 Cordis 插件。"
   },
-  "added": "2026-08-15"
+  "added": "2026-08-14"
 }


### PR DESCRIPTION
## Submit dsh-reverse-skill to the catalog

Per the maintainer's `CHANGES_REQUESTED` review, this PR now contains **only** the new catalog source file `catalog/plugins/dhicoc--dsh-reverse-skill.json`. `README.md` has been reverted to upstream (it is a generated projection and must not be edited by contributors).

### Self-test (verified locally before submission)
```
cd dsh-reverse-skill && node _selftest.mjs
plugin export name     : reverse-skill
inject                 : ["skills"]
providers registered   : 1
total candidates       : 85      (matches the 85 SKILL.md claim)
unique candidate names : 85      (no duplicates)
userInvocable          : 83 / 85
modelInvocable         : 85 / 85
get() first body chars : 3661    (skill body served on demand)
```
The plugin registers 85 skills through the `ctx.skills` seam that dsh provides at runtime, and the repo already declares `dsh.bundle.patch` + commits `cordis.patch.yml` (verified by maintainers). Install: `dsh plugin add github:dhicoc/dsh-reverse-skill`.