### PR TITLE
Add dsh-mcp-lens catalog entry

### DIFF
--- a/catalog/plugins/labmimors--dsh-mcp-lens.json
+++ b/catalog/plugins/labmimors--dsh-mcp-lens.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/labmimors/dsh-mcp-lens",
   "category": "tools",
   "description": {
-    "en": "Progressive-disclosure MCP gateway for DeepSeek Harness: it keeps two model-facing tools and exposes exact remote MCP schemas lazily at call time.",
-    "zh": "DeepSeek Harness 的渐进式披露 MCP 网关：保持两个面向模型的工具，并在调用时按需暴露远程 MCP 的精确 schema。"
+    "en": "Progressive-disclosure MCP gateway for DeepSeek Harness: it keeps two model-facing tools, reveals ranked exact remote input schemas on demand, then calls an explicit server/tool pair.",
+    "zh": "DeepSeek Harness 的渐进式披露 MCP 网关：保持两个面向模型的工具，按需返回排序后的远端精确 inputSchema，再调用明确的 server/tool。"
   },
   "added": "2026-08-15"
 }

--- a/catalog/plugins/labmimors--dsh-mcp-lens.json
+++ b/catalog/plugins/labmimors--dsh-mcp-lens.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "labmimors/dsh-mcp-lens",
+  "name": "dsh-mcp-lens",
+  "repository": "https://github.com/labmimors/dsh-mcp-lens",
+  "category": "tools",
+  "description": {
+    "en": "Progressive-disclosure MCP gateway for DeepSeek Harness: it keeps two model-facing tools and exposes exact remote MCP schemas lazily at call time.",
+    "zh": "DeepSeek Harness 的渐进式披露 MCP 网关：保持两个面向模型的工具，并在调用时按需暴露远程 MCP 的精确 schema。"
+  },
+  "added": "2026-08-15"
+}


### PR DESCRIPTION
## Summary

As the maintainer of `labmimors/dsh-mcp-lens`, I am submitting one catalog entry for the current `v0.1.0-rc.9` release candidate.

- Adds exactly one new `catalog/plugins/labmimors--dsh-mcp-lens.json` file.
- Description is limited to verifiable facts from the public repository and release.

## Verified facts used

- Repository: `https://github.com/labmimors/dsh-mcp-lens`
- Current release candidate: `v0.1.0-rc.9` (published 2026-08-15, prerelease)
- The repository carries the `dsh-plugin` topic.
- The package declares `dsh.bundle.patch` in `package.json`.

## Notes

- This PR does not ask for stars or endorsements.
- I tested the plugin in my own environment before submission; this PR itself changes catalog metadata only.
