### PR TITLE
fix: isolate repository discovery failures

### DIFF
--- a/apps/web/tests/github-discovery.test.ts
+++ b/apps/web/tests/github-discovery.test.ts
@@ -95,6 +95,102 @@ describe('Cloudflare GitHub discovery', () => {
     expect(request).toHaveBeenCalledTimes(3)
   })
 
+  it.each([
+    [{ full_name: 'deepseek-ai/deepseek-harness' }, 'excluded_repository'],
+    [{ fork: true }, 'fork'],
+    [{ archived: true }, 'archived'],
+    [{ disabled: true }, 'disabled'],
+    [{ default_branch: '' }, 'missing_default_branch'],
+  ])('rejects repository metadata before making API calls', async (overrides, code) => {
+    const request = vi.fn()
+
+    const result = await inspectRepository(
+      { request } as unknown as ReturnType<typeof createGitHubClient>,
+      repository(overrides),
+    )
+
+    expect(result).toMatchObject({ status: 'rejected', code })
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [{ truncated: true, tree: [] }, 'truncated_tree'],
+    [{ truncated: false, tree: [] }, 'missing_package'],
+  ])('rejects an unusable repository tree', async (tree, code) => {
+    const request = vi.fn(async () => tree)
+
+    const result = await inspectRepository(
+      { request } as unknown as ReturnType<typeof createGitHubClient>,
+      repository(),
+    )
+
+    expect(result).toMatchObject({ status: 'rejected', code })
+  })
+
+  it.each([
+    [{ encoding: 'utf-8', content: '{}' }, 'unreadable_file'],
+    [{ encoding: 'base64', content: Buffer.from('{').toString('base64') }, 'invalid_package'],
+    [{ encoding: 'base64', content: encodedJson({ name: 'plugin' }) }, 'missing_bundle'],
+    [{
+      encoding: 'base64',
+      content: encodedJson({ name: 'plugin', dsh: { bundle: { patch: '../../escape.patch' } } }),
+    }, 'invalid_bundle_patch'],
+    [{
+      encoding: 'base64',
+      content: encodedJson({ name: 'plugin', dsh: { bundle: { patch: './missing.patch' } } }),
+    }, 'missing_bundle_patch'],
+  ])('rejects an invalid plugin manifest without aborting the scan', async (blob, code) => {
+    const request = vi.fn(async (path: string) => path.includes('/git/trees/')
+      ? {
+          truncated: false,
+          tree: [
+            { path: 'package.json', mode: '100644', type: 'blob', sha: 'manifest' },
+            { path: 'plugin.patch', mode: '100644', type: 'blob', sha: 'patch' },
+          ],
+        }
+      : blob)
+
+    const result = await inspectRepository(
+      { request } as unknown as ReturnType<typeof createGitHubClient>,
+      repository(),
+    )
+
+    expect(result).toMatchObject({ status: 'rejected', code })
+  })
+
+  it.each([
+    [404, 'Not Found', 'repository_unavailable'],
+    [409, 'Git Repository is empty.', 'empty_repository'],
+    [410, 'Gone', 'repository_unavailable'],
+    [422, 'Reference does not exist', 'invalid_repository_tree'],
+  ])('isolates repository-scoped GitHub API status %i', async (status, message, code) => {
+    const fetcher = vi.fn(async () => Response.json({ message }, { status })) as unknown as typeof fetch
+
+    const result = await inspectRepository(createGitHubClient('token', fetcher), repository({
+      full_name: 'ShawnSiao/dsh-agent-eval',
+    }))
+
+    expect(result).toMatchObject({
+      githubId: 42,
+      status: 'rejected',
+      code,
+    })
+  })
+
+  it('does not hide authentication or rate-limit failures as repository rejections', async () => {
+    const fetcher = vi.fn(async () => Response.json(
+      { message: 'API rate limit exceeded' },
+      { status: 403, headers: { 'x-ratelimit-remaining': '0' } },
+    )) as unknown as typeof fetch
+
+    await expect(inspectRepository(createGitHubClient('token', fetcher), repository()))
+      .rejects.toMatchObject({
+        name: 'GitHubApiError',
+        status: 403,
+        rateLimitRemaining: 0,
+      })
+  })
+
   it('paces repository search after the first request', async () => {
     const waiter = vi.fn(async () => undefined)
     const fetcher = vi.fn(async () => Response.json({ ok: true })) as unknown as typeof fetch

--- a/apps/web/worker/lib/github-discovery.ts
+++ b/apps/web/worker/lib/github-discovery.ts
@@ -309,6 +309,19 @@ function rejection(repository: GitHubRepository, error: RepositoryRejection): Re
   }
 }
 
+function repositoryApiRejection(error: GitHubApiError): RepositoryRejection | null {
+  if (error.status === 404 || error.status === 410) {
+    return new RepositoryRejection('repository_unavailable', error.message)
+  }
+  if (error.status === 409) {
+    return new RepositoryRejection('empty_repository', error.message)
+  }
+  if (error.status === 422) {
+    return new RepositoryRejection('invalid_repository_tree', error.message)
+  }
+  return null
+}
+
 export async function inspectRepository(
   client: GitHubClient,
   repository: GitHubRepository,
@@ -365,6 +378,10 @@ export async function inspectRepository(
     throw lastRejection ?? new RepositoryRejection('missing_bundle', 'No package declares dsh.bundle')
   } catch (error) {
     if (error instanceof RepositoryRejection) return rejection(repository, error)
+    if (error instanceof GitHubApiError) {
+      const apiRejection = repositoryApiRejection(error)
+      if (apiRejection) return rejection(repository, apiRejection)
+    }
     throw error
   }
 }


### PR DESCRIPTION
## Summary

- isolate repository-scoped GitHub API failures so one unavailable repository cannot abort the entire discovery run
- classify 404/410 as `repository_unavailable`, 409 as `empty_repository`, and 422 as `invalid_repository_tree`
- preserve authentication, rate-limit, network, and GitHub service failures as task-level errors
- expand validation tests for metadata exclusions, unusable trees, invalid manifests, and API failure boundaries

## Root cause

`ShawnSiao/dsh-agent-eval` returned 404 for its default-branch tree. The validator only converted local validation errors into repository rejections, so the GitHub API exception escaped and failed every scheduled run. Because the repository remained pending, each subsequent run selected it again and failed in the same place.

## Production verification

- deployed Worker version `4b2d615b-15a0-4a2f-a776-e4c241bf31f9`
- natural `37 * * * *` Cron run `cd1c5fc3-903a-4a11-bcf8-347bd5eef447` completed successfully
- processed 925 accepted and 450 rejected repositories with no task-level error
- public `/plugins.json` refreshed from KV and contains 1,356 entries
- existing encrypted `GITHUB_TOKEN` secret remains unchanged
- formal Cron schedules remain unchanged

## Checks

- targeted regression test demonstrated the failure before the implementation
- full repository test suite
- 49 Web tests plus 31 repository script tests
- focused coverage: 84.61% statements, 80% branches, 80% functions, 84.56% lines
- Cloudflare generated type check
- production build
- source and bundle credential scan
