### PR TITLE
fix: repair Cloudflare plugin discovery

### DIFF
--- a/apps/web/tests/app.test.ts
+++ b/apps/web/tests/app.test.ts
@@ -302,6 +302,21 @@ describe('market API', () => {
     expect(curatedSyncer).not.toHaveBeenCalled()
   })
 
+  it('fails closed when the configured catalog sync token is too short', async () => {
+    const { app, curatedSyncer } = syncApp()
+    const response = await app.request(
+      '/api/v1/catalog/sync',
+      syncRequest({ source: 'github_ci', entries: [VALID_SYNC_ENTRY] }, 'short-token'),
+      {
+        CATALOG_DB: {},
+        CATALOG_SYNC_TOKEN: 'short-token',
+      } as unknown as Env,
+    )
+
+    expect(response.status).toBe(503)
+    expect(curatedSyncer).not.toHaveBeenCalled()
+  })
+
   it('validates the catalog sync payload', async () => {
     const { app, curatedSyncer } = syncApp()
 
@@ -338,6 +353,26 @@ describe('market API', () => {
       SYNC_ENV,
     )
     expect(extraField.status).toBe(400)
+
+    const nonGitHubRepository = await app.request(
+      '/api/v1/catalog/sync',
+      syncRequest({
+        source: 'github_ci',
+        entries: [{ ...VALID_SYNC_ENTRY, repository: 'https://example.com/openma-ai/deepseek-harness-tui' }],
+      }),
+      SYNC_ENV,
+    )
+    expect(nonGitHubRepository.status).toBe(400)
+
+    const mismatchedRepository = await app.request(
+      '/api/v1/catalog/sync',
+      syncRequest({
+        source: 'github_ci',
+        entries: [{ ...VALID_SYNC_ENTRY, repository: 'https://github.com/attacker/other-repository' }],
+      }),
+      SYNC_ENV,
+    )
+    expect(mismatchedRepository.status).toBe(400)
     expect(curatedSyncer).not.toHaveBeenCalled()
   })
 

--- a/apps/web/tests/github-discovery.test.ts
+++ b/apps/web/tests/github-discovery.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   createGitHubClient,
+  discoveryInternals,
   discoverRepositories,
   incrementalStart,
   inspectRepository,
@@ -33,13 +34,19 @@ function encodedJson(value: unknown): string {
 }
 
 describe('Cloudflare GitHub discovery', () => {
-  it('uses an overlap window and exhausts incremental search pages', async () => {
+  it('uses an overlap window and combines created and pushed incremental searches', async () => {
     expect(incrementalStart('2026-08-14T12:00:00Z')).toBe('2026-08-14T11:55:00Z')
-    const request = vi.fn(async (_path: string) => ({
-      total_count: 1,
-      incomplete_results: false,
-      items: [repository()],
-    }))
+    const request = vi.fn(async (path: string) => path.includes('created%3A')
+      ? {
+          total_count: 1,
+          incomplete_results: false,
+          items: [repository()],
+        }
+      : {
+          total_count: 2,
+          incomplete_results: false,
+          items: [repository(), repository({ id: 43, full_name: 'owner/second-plugin' })],
+        })
     const repositories = await discoverRepositories(
       { request } as unknown as ReturnType<typeof createGitHubClient>,
       'dsh-plugin',
@@ -48,9 +55,26 @@ describe('Cloudflare GitHub discovery', () => {
       '2026-08-14T12:30:00Z',
     )
 
-    expect(repositories.map((item) => item.id)).toEqual([42])
-    expect(request).toHaveBeenCalledOnce()
-    expect(request.mock.calls[0]?.[0]).toContain('updated%3A2026-08-14T11%3A55%3A00Z..2026-08-14T12%3A30%3A00Z')
+    expect(repositories.map((item) => item.id)).toEqual([42, 43])
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(request.mock.calls[0]?.[0]).toContain('created%3A2026-08-14T11%3A55%3A00Z..2026-08-14T12%3A30%3A00Z')
+    expect(request.mock.calls[1]?.[0]).toContain('pushed%3A2026-08-14T11%3A55%3A00Z..2026-08-14T12%3A30%3A00Z')
+    expect(request.mock.calls[0]?.[0]).toContain('sort=updated')
+    expect(request.mock.calls[1]?.[0]).toContain('sort=updated')
+    expect(request.mock.calls.flat().join(' ')).not.toContain('updated%3A')
+  })
+
+  it('forces one full discovery when the search strategy version changes', () => {
+    const watermark = '2026-08-14T12:00:00Z'
+    expect(discoveryInternals.selectMode(undefined, null, null)).toBe('full')
+    expect(discoveryInternals.selectMode(undefined, watermark, null)).toBe('full')
+    expect(discoveryInternals.selectMode(
+      undefined,
+      watermark,
+      discoveryInternals.strategyVersion,
+    )).toBe('incremental')
+    expect(discoveryInternals.selectMode('full', watermark, discoveryInternals.strategyVersion))
+      .toBe('full')
   })
 
   it('validates a nested monorepo package without downloading dependencies', async () => {

--- a/apps/web/worker/app.ts
+++ b/apps/web/worker/app.ts
@@ -96,6 +96,23 @@ function boundedString(value: unknown, maxLength: number): value is string {
   return typeof value === 'string' && value.length > 0 && value.length <= maxLength
 }
 
+function isCanonicalGitHubRepositoryUrl(repositoryId: string, value: string): boolean {
+  try {
+    const url = new URL(value)
+    const pathname = url.pathname.replace(/\/$/, '')
+    return url.protocol === 'https:' &&
+      url.hostname.toLocaleLowerCase('en-US') === 'github.com' &&
+      url.port === '' &&
+      url.username === '' &&
+      url.password === '' &&
+      url.search === '' &&
+      url.hash === '' &&
+      pathname.toLocaleLowerCase('en-US') === `/${repositoryId.toLocaleLowerCase('en-US')}`
+  } catch {
+    return false
+  }
+}
+
 type CatalogSyncParseResult =
   | { ok: true; entries: CuratedCatalogEntry[] }
   | { ok: false; error: string }
@@ -108,7 +125,8 @@ function parseCuratedEntry(value: unknown, index: number): CuratedCatalogEntry |
     return `Entry ${index} has an invalid id.`
   }
   if (!boundedString(value.name, 200)) return `Entry ${index} has an invalid name.`
-  if (!boundedString(value.repository, 300) || !/^https:\/\//.test(value.repository)) {
+  if (!boundedString(value.repository, 300) ||
+    !isCanonicalGitHubRepositoryUrl(value.id, value.repository)) {
     return `Entry ${index} has an invalid repository URL.`
   }
   if (!boundedString(value.category, 40) || !isKnownCategoryId(value.category)) {
@@ -299,7 +317,7 @@ export function createApp(overrides: Partial<AppDependencies> = {}) {
 
   app.post('/api/v1/catalog/sync', async (context) => {
     const configuredToken = context.env?.CATALOG_SYNC_TOKEN?.trim()
-    if (!configuredToken || !context.env?.CATALOG_DB) {
+    if (!configuredToken || configuredToken.length < 32 || !context.env?.CATALOG_DB) {
       return context.json({ error: 'Catalog sync is not configured.' }, 503)
     }
 

--- a/apps/web/worker/lib/github-discovery.ts
+++ b/apps/web/worker/lib/github-discovery.ts
@@ -3,6 +3,7 @@ const SEARCH_RESULT_LIMIT = 1000
 const FIRST_GITHUB_INSTANT = '2008-01-01T00:00:00Z'
 const MAX_PACKAGE_MANIFESTS = 25
 const DEFAULT_EXCLUSIONS = new Set(['deepseek-ai/deepseek-harness'])
+export const DISCOVERY_STRATEGY_VERSION = 'created-pushed-v1'
 
 type JsonObject = Record<string, unknown>
 
@@ -159,21 +160,25 @@ function midpoint(start: string, end: string): string {
   return isoSecond(new Date(left + Math.floor((right - left) / 2_000) * 1_000))
 }
 
-function searchQuery(topic: string, qualifier: 'created' | 'updated', start: string, end: string): string {
+type SearchDateQualifier = 'created' | 'pushed'
+
+function searchQuery(topic: string, qualifier: SearchDateQualifier, start: string, end: string): string {
   return [`topic:${topic}`, 'fork:false', 'archived:false', `${qualifier}:${start}..${end}`].join(' ')
 }
 
 async function searchPage(
   client: GitHubClient,
   topic: string,
-  qualifier: 'created' | 'updated',
+  qualifier: SearchDateQualifier,
   start: string,
   end: string,
   page: number,
 ): Promise<SearchResponse> {
   const parameters = new URLSearchParams({
     q: searchQuery(topic, qualifier, start, end),
-    sort: qualifier,
+    // Repository Search only documents `updated` (plus stars/forks/help-wanted)
+    // as a sort key. The date qualifier still controls the created/pushed range.
+    sort: 'updated',
     order: 'desc',
     per_page: '100',
     page: String(page),
@@ -191,7 +196,7 @@ async function searchPage(
 async function collectRange(
   client: GitHubClient,
   topic: string,
-  qualifier: 'created' | 'updated',
+  qualifier: SearchDateQualifier,
   start: string,
   end: string,
 ): Promise<GitHubRepository[]> {
@@ -231,10 +236,30 @@ export async function discoverRepositories(
   start: string | null,
   end: string,
 ): Promise<GitHubRepository[]> {
-  const qualifier = mode === 'full' ? 'created' : 'updated'
   const rangeStart = mode === 'full' ? FIRST_GITHUB_INSTANT : start
   if (rangeStart === null) throw new Error('Incremental discovery requires a watermark')
-  return uniqueRepositories(await collectRange(client, topic, qualifier, rangeStart, end))
+  if (mode === 'full') {
+    return uniqueRepositories(await collectRange(client, topic, 'created', rangeStart, end))
+  }
+
+  // GitHub repository search does not support an `updated:` qualifier. Query
+  // both supported signals so newly-created repositories and existing plugins
+  // with fresh pushes are discovered, then deduplicate repositories present in
+  // both result sets. The weekly full scan remains the safety net for an old
+  // repository that only adds/removes the topic without a push.
+  const created = await collectRange(client, topic, 'created', rangeStart, end)
+  const pushed = await collectRange(client, topic, 'pushed', rangeStart, end)
+  return uniqueRepositories([...created, ...pushed])
+}
+
+export function selectDiscoveryMode(
+  requestedMode: 'incremental' | 'full' | undefined,
+  watermark: string | null,
+  strategyVersion: string | null,
+): 'incremental' | 'full' {
+  if (requestedMode === 'full' || watermark === null) return 'full'
+  if (requestedMode === 'incremental') return 'incremental'
+  return strategyVersion === DISCOVERY_STRATEGY_VERSION ? 'incremental' : 'full'
 }
 
 function decodeBlob(blob: GitBlobResponse, label: string): string {
@@ -394,4 +419,6 @@ export const discoveryInternals = {
   instantBefore,
   midpoint,
   searchQuery,
+  selectMode: selectDiscoveryMode,
+  strategyVersion: DISCOVERY_STRATEGY_VERSION,
 }

--- a/apps/web/worker/lib/plugin-discovery-task.ts
+++ b/apps/web/worker/lib/plugin-discovery-task.ts
@@ -14,9 +14,11 @@ import {
 import { refreshCatalogSnapshot } from './catalog-store'
 import {
   createGitHubClient,
+  DISCOVERY_STRATEGY_VERSION,
   discoverRepositories,
   incrementalStart,
   inspectRepository,
+  selectDiscoveryMode,
 } from './github-discovery'
 
 const DEFAULT_TOPIC = 'dsh-plugin'
@@ -25,6 +27,7 @@ const VALIDATION_CHUNK_SIZE = 20
 const CORE_RATE_LIMIT_RESERVE = 500
 const TASK_DEADLINE_MS = 12 * 60 * 1000
 const LEASE_MS = 20 * 60 * 1000
+const DISCOVERY_STRATEGY_STATE_KEY = 'discovery_strategy_version'
 
 interface RateLimitResponse {
   resources: {
@@ -79,7 +82,8 @@ export async function runPluginDiscoveryTask(
     leaseClaimed = await claimScanLease(env.CATALOG_DB, runId, runAt, LEASE_MS)
     if (!leaseClaimed) return { ...counters, mode, skipped: true }
     const watermark = await getCatalogState(env.CATALOG_DB, 'discovery_watermark')
-    mode = requestedMode ?? (watermark === null ? 'full' : 'incremental')
+    const strategyVersion = await getCatalogState(env.CATALOG_DB, DISCOVERY_STRATEGY_STATE_KEY)
+    mode = selectDiscoveryMode(requestedMode, watermark, strategyVersion)
     await startScanRun(env.CATALOG_DB, runId, mode, end)
 
     const client = createGitHubClient(env.GITHUB_TOKEN.trim())
@@ -127,6 +131,14 @@ export async function runPluginDiscoveryTask(
 
     if (mode === 'full') await markMissingTopicRepositories(env.CATALOG_DB, runId, end)
     await setCatalogState(env.CATALOG_DB, 'discovery_watermark', end, end)
+    if (mode === 'full') {
+      await setCatalogState(
+        env.CATALOG_DB,
+        DISCOVERY_STRATEGY_STATE_KEY,
+        DISCOVERY_STRATEGY_VERSION,
+        end,
+      )
+    }
     const completedAt = new Date().toISOString()
     await completeScanRun(env.CATALOG_DB, runId, 'completed', counters, undefined, completedAt)
     await refreshCatalogSnapshot(env, fetch, new Date(completedAt).getTime())

--- a/docs/api.md
+++ b/docs/api.md
@@ -78,9 +78,12 @@ Full-catalog reconciliation from GitHub CI — one of exactly two catalog write 
 other is the Worker's own cron topic scan).
 
 Authentication: `Authorization: Bearer <CATALOG_SYNC_TOKEN>` where the token is a Cloudflare
-Worker secret. Responses:
+Worker secret of at least 32 bytes. The endpoint is not a public submission API: anonymous and
+incorrectly authenticated callers cannot create or update catalog entries. Every accepted
+repository URL must be the canonical `https://github.com/<owner>/<repository>` URL matching the
+entry ID. Responses:
 
-- `503` when the secret is not configured on the Worker;
+- `503` when the secret is missing or too short on the Worker;
 - `401` when the token does not match (constant-time comparison);
 - `200 {"ok": true, "total": N, "removedSources": M}` on success.
 

--- a/docs/plugin-discovery.md
+++ b/docs/plugin-discovery.md
@@ -26,7 +26,10 @@ topic never silently removes a maintainer-approved entry.
 ## Schedules and failure behavior
 
 - `7 * * * *` and `37 * * * *`: Cron Triggers dispatch incremental GitHub discovery every
-  30 minutes, with a five-minute overlap.
+  30 minutes, with a five-minute overlap. Each incremental run combines GitHub's supported
+  `created:` and `pushed:` repository searches and deduplicates the results. This captures new
+  repositories and fresh plugin pushes; the weekly full reconciliation catches topic-only
+  changes on otherwise inactive repositories.
 - `17 3 * * SUN`: weekly full reconciliation, partitioned by repository creation timestamp to
   exhaust GitHub Search's 1,000-result window.
 - `*/15 * * * *`: refresh the published catalog/star-growth snapshot.
@@ -36,6 +39,10 @@ cannot overlap another discovery run. Work that exceeds the deadline or GitHub b
 pending for the next half-hour invocation. Each run has a durable scan record, and each GitHub source record stores the
 last full run that saw it. A repository is marked as no longer carrying the topic only after a
 successful full scan. The watermark advances only during the final publish step.
+
+The Worker stores a discovery-strategy version in D1. A deployment that changes the search
+strategy forces one successful full reconciliation before incremental discovery resumes. This
+provides an automatic production backfill without deleting the watermark or editing D1 by hand.
 
 Validation reads the default-branch Git tree and at most 25 root or nested `package.json`
 blobs. It never installs dependencies or executes repository code. It requires a package name,
@@ -49,18 +56,18 @@ apart (at most 28.6/minute). Every validation batch checks `/rate_limit`, proces
 serially, and preserves 500 core calls for the website and other automation. Pending validation
 continues in the next half-hour run instead of exhausting the token.
 
-At the current scale of roughly 2,100 topic repositories:
+At the current scale of roughly 3,300 topic repositories:
 
 | Work | Expected calls |
 | --- | ---: |
-| Half-hour search with fewer than 100 updated repositories | 1 Search request |
+| Half-hour created + pushed search with fewer than 100 results each | 2 Search requests |
 | Validation of one ordinary single-package repository | 2 core requests |
 | Weekly full discovery | roughly 25–35 Search requests |
-| First validation backfill, if most repositories have one manifest | roughly 4,200 core requests |
+| First validation backfill, if most repositories have one manifest | roughly 6,600 core requests |
 
-The initial backfill is therefore close to, but normally below, one 5,000-request core window.
-The 500-call reserve makes the upper bound safe; monorepos that need extra manifest reads simply
-carry over. The limit is shared by all tokens acting as the same GitHub user, so use a dedicated,
+The initial backfill can span more than one 5,000-request core window. The 500-call reserve makes
+that safe; remaining validation work carries over to later half-hour runs. The limit is shared by
+all tokens acting as the same GitHub user, so use a dedicated,
 read-only fine-grained token. A GitHub App is the later upgrade path if this automation needs an
 isolated and scalable quota.
 


### PR DESCRIPTION
## What changed

- replace the unsupported GitHub repository `updated:` qualifier with deduplicated `created:` and `pushed:` searches
- force one full discovery when the search-strategy version changes so production backfills automatically
- harden catalog sync so only canonical GitHub URLs matching each `owner/repository` ID are accepted
- fail closed when the configured catalog sync secret is shorter than 32 bytes
- add regression tests and update operations/API documentation

## Root cause

GitHub repository search does not support `updated:` as a date qualifier. The API returned a successful empty result, so Cloudflare recorded completed incremental runs with zero discovered repositories.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run cf-typecheck`
- `npm run readme:check`
- `wrangler deploy --dry-run`
- `npm audit --audit-level=high`
- local Worker preview: health 200, unauthenticated catalog sync 503, catalog page 200
- OSS privacy scan of the staged diff
