### PR TITLE
catalog: classify SandBase Harness runtime

### DIFF
--- a/catalog/plugins/sandbaseai--sandbase-harness.json
+++ b/catalog/plugins/sandbaseai--sandbase-harness.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "sandbaseai/sandbase-harness",
+  "name": "sandbase-harness",
+  "repository": "https://github.com/sandbaseai/sandbase-harness",
+  "category": "dev",
+  "description": {
+    "en": "Local-first agent runtime with persistent sessions, sandbox backends, audit and replay, plus a DSH bundle exposing its MCP bridge.",
+    "zh": "本地优先的 Agent 运行时，提供持久会话、沙箱后端、审计与回放，并通过 DSH bundle 暴露 MCP bridge。"
+  },
+  "added": "2026-08-15"
+}


### PR DESCRIPTION
## Plugin

Repository: https://github.com/sandbaseai/sandbase-harness

Classifies the already topic-discovered SandBase Harness entry under **Development & Runtime** and adds neutral English and Chinese descriptions. SandBase Harness is a local-first agent runtime with persistent sessions, sandbox backends, audit and replay; its DSH bundle starts the six-tool stdio MCP bridge.

## Author verification

Tested from the current SandBase Harness branch with:

```text
npm run release:check
```

Results:

- typecheck passed
- 574 tests passed; 15 environment-dependent tests skipped
- runtime and Console production builds passed
- `npm pack --dry-run` passed with an isolated cache
- release smoke passed: `release smoke: ok`

The catalog's own review was also run locally against the latest upstream base:

```text
PASS sandbaseai/sandbase-harness: package.json -> examples/deepseek-harness/cordis.yml
```

## Catalog submissions

- [x] This PR adds exactly one `catalog/plugins/*.json` file and changes nothing else
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a non-draft PR passing the static review is merged automatically, and the website catalog and README directories refresh automatically afterwards

## Disclosure

I am affiliated with SandBase. AI assistance was used to research, prepare, and verify this metadata-only submission.
