### PR TITLE
catalog: add dsh-1024store

### DIFF
--- a/catalog/plugins/imsai-sh--awesome-deepseek-harness-plugins.json
+++ b/catalog/plugins/imsai-sh--awesome-deepseek-harness-plugins.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "imsai-sh/awesome-deepseek-harness-plugins",
+  "name": "dsh-1024store",
+  "repository": "https://github.com/imsai-sh/awesome-deepseek-harness-plugins",
+  "category": "tools",
+  "description": {
+    "en": "The DSH 1024Store client plugin: browse and search the live deepseek1024.com catalog from Settings, filter by category, confirmed one-click installs and uninstalls, plus self-update checks.",
+    "zh": "DSH 1024Store 官方商店插件：设置页内浏览/搜索 deepseek1024.com 实时目录，按分类筛选，确认后一键安装/卸载，支持自更新检查。"
+  },
+  "added": "2026-08-15"
+}


### PR DESCRIPTION
## Plugin submission

- Repository: https://github.com/imsai-sh/awesome-deepseek-harness-plugins
- Category: `tools`

## Checklist

- [x] This PR adds exactly one new `catalog/plugins/<owner>--<repository>.json` file and changes nothing else.
- [x] The plugin repository's `package.json` declares `dsh.bundle.patch` and the patch file exists (`packages/dsh-1024store/package.json` → `cordis.patch.yml`).
- [x] Descriptions are provided in both English and Chinese.
- [x] I understand eligible non-draft submissions are squash-merged automatically after the trusted static review.

Note: this is the store's own client plugin (`dsh-1024store` on npm), submitted through the standard contributor flow as an end-to-end test of the automation chain.