### PR TITLE
catalog: add ben7am1n/dsh-telegram

### DIFF
--- a/catalog/plugins/ben7am1n--dsh-telegram.json
+++ b/catalog/plugins/ben7am1n--dsh-telegram.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ben7am1n/dsh-telegram",
+  "name": "dsh-telegram",
+  "repository": "https://github.com/ben7am1n/dsh-telegram",
+  "category": "notify",
+  "description": {
+    "en": "Native Telegram bridge for DeepSeek Harness: chat with dsh agents from your phone, control sessions and manage the harness.",
+    "zh": "DeepSeek Harness 原生 Telegram 桥：在手机上与 dsh agent 聊天、控制会话并管理 harness。"
+  },
+  "added": "2026-08-16"
+}


### PR DESCRIPTION
Add catalog entry for ben7am1n/dsh-telegram (native Telegram bridge for DeepSeek Harness, category: notify).

- package.json declares dsh.bundle.patch = ./cordis.patch.yml
- repo has dsh-plugin topic
- install: dsh plugin --profile web add github:ben7am1n/dsh-telegram