### PR TITLE
test: verify failed review keeps PR open

### DIFF
--- a/docs/ci-review-open-state-test.md
+++ b/docs/ci-review-open-state-test.md
@@ -1,0 +1,3 @@
+# CI review open-state test
+
+This temporary file intentionally violates the catalog submission rule. The test verifies that a failed static review reports the error while leaving the pull request open for corrections.


### PR DESCRIPTION
## Purpose

Production smoke test for the plugin-submission review workflow.

This PR intentionally changes a non-catalog file so the trusted static review must fail. Expected behavior:

- the workflow posts the failure reason;
- the PR remains open after the failed review;
- no catalog data is merged.

The PR will be closed manually and the branch deleted after verification.