### PR TITLE
Add dsh-skillgovern catalog entry

### DIFF
--- a/catalog/plugins/xiaopeng212321414321413231--critical-skillgovern--dsh-plugin.json
+++ b/catalog/plugins/xiaopeng212321414321413231--critical-skillgovern--dsh-plugin.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Xiaopeng212321414321413231/critical-skillgovern/dsh-plugin",
+  "name": "dsh-skillgovern",
+  "repository": "https://github.com/Xiaopeng212321414321413231/critical-skillgovern",
+  "category": "skill",
+  "description": {
+    "en": "Skill routing governance tools - diagnose routing health, batch audit skill libraries, and classify skills into 7 major / 19 sub categories.",
+    "zh": "技能路由治理工具集 - 诊断技能路由健康度、批量审计技能库、按 7 大类 19 子类结构化分类技能。"
+  },
+  "added": "2026-08-17"
+}

--- a/catalog/plugins/xiaopeng212321414321413231--critical-skillgovern--dsh-plugin.json
+++ b/catalog/plugins/xiaopeng212321414321413231--critical-skillgovern--dsh-plugin.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "../schema/plugin.schema.json",
   "id": "Xiaopeng212321414321413231/critical-skillgovern/dsh-plugin",
   "name": "dsh-skillgovern",


### PR DESCRIPTION
﻿## Summary
- Add `dsh-skillgovern` plugin to the catalog (skill category)
- Plugin provides 3 skill governance tools for DeepSeek Harness: `skill-diagnose`, `skill-audit`, `skill-classify`
- Source repo: https://github.com/Xiaopeng212321414321413231/critical-skillgovern (subdirectory: `dsh-plugin/`)

## Plugin details
- **id**: `Xiaopeng212321414321413231/critical-skillgovern/dsh-plugin`
- **category**: `skill`
- **patch file**: `dsh-plugin/cordis.patch.yml` (exists in repo)
- **GitHub topic**: `dsh-plugin` added to source repo
