### PR TITLE
catalog: add dsh-workflow-isolate

### DIFF
--- a/catalog/plugins/linxiushen--dsh-workflow-isolate.json
+++ b/catalog/plugins/linxiushen--dsh-workflow-isolate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Linxiushen/dsh-workflow-isolate",
+  "name": "dsh-workflow-isolate",
+  "repository": "https://github.com/Linxiushen/dsh-workflow-isolate",
+  "category": "workflow",
+  "description": {
+    "en": "Alternative WorkflowEngine provider for DSH 0.1.0-rc.7 that runs model-written orchestration in fresh QuickJS/WASM runtimes with a JSON-only host bridge and bounded guest and child-agent resources.",
+    "zh": "面向 DSH 0.1.0-rc.7 的替代 WorkflowEngine provider：每次运行都新建 QuickJS/WASM 运行时，仅以 JSON 桥接宿主，并限制 Guest 与子 Agent 资源。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## Summary

Adds `Linxiushen/dsh-workflow-isolate` as one repository-level catalog entry in the `workflow` category.

## Verification

- root `package.json` declares `dsh.bundle.patch` as `./cordis.patch.yml`;
- the referenced patch is committed;
- `v0.1.0` targets DeepSeek Harness `0.1.0-rc.7`;
- 41 tests plus production and release-package smoke checks pass;
- CI passes on Ubuntu and Windows with Node.js 22.19 and 24;
- the repository has the `dsh-plugin` topic.

Distribution is currently through the GitHub release tarball rather than npm. The catalog may therefore classify a direct GitHub install separately from the verified release asset.