### PR TITLE
catalog: add UllrAI/dsh-mqtt

### DIFF
--- a/catalog/plugins/ullrai--dsh-mqtt.json
+++ b/catalog/plugins/ullrai--dsh-mqtt.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "UllrAI/dsh-mqtt",
+  "name": "dsh-mqtt",
+  "repository": "https://github.com/UllrAI/dsh-mqtt",
+  "category": "notify",
+  "description": {
+    "en": "MQTT protocol driver and agent worker gateway for submitting, steering, observing, and cancelling DeepSeek Harness sessions.",
+    "zh": "通过 MQTT 提交、引导、观察和取消 DeepSeek Harness 会话的协议驱动与 Agent Worker 网关。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## Summary

Add [UllrAI/dsh-mqtt](https://github.com/UllrAI/dsh-mqtt) to the plugin catalog.

`dsh-mqtt` is an MQTT protocol driver and agent worker gateway for submitting, steering, observing, and cancelling DeepSeek Harness sessions.

## Submission checks

- adds exactly one `catalog/plugins/*.json` entry
- repository exposes the `dsh-plugin` topic
- `package.json` declares `dsh.bundle.patch`
- the referenced `cordis.patch.yml` is committed
- published as `dsh-mqtt@0.1.0` on npm