### PR TITLE
catalog: add tokentopo-ai/dsh-octo

### DIFF
--- a/catalog/plugins/tokentopo-ai--dsh-octo.json
+++ b/catalog/plugins/tokentopo-ai--dsh-octo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "tokentopo-ai/dsh-octo",
+  "name": "dsh-octo",
+  "repository": "https://github.com/tokentopo-ai/dsh-octo",
+  "category": "skill",
+  "description": {
+    "en": "Installs a dsh skill and official Claude Code, Codex, and DeepSeek subagent integrations for staged planning, implementation, review, and optional experiment workflows on complex tasks.",
+    "zh": "为 dsh 安装一项技能及 Claude Code、Codex 与 DeepSeek 官方 subagent 集成，用于在复杂任务中按阶段组织计划、实现、审核与可选实验流程。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## 摘要

将 [`tokentopo-ai/dsh-octo`](https://github.com/tokentopo-ai/dsh-octo) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`npm test`；`npm run pack:check`；`npm run test:bundle`
- 测试结果：此前作者验收均通过：Node TAP 8/8；npm pack dry-run 仅包含发布白名单文件；隔离 dsh profile 验证结果为 `skill=1 providers=3 tools=4`

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
