### PR TITLE
catalog: add sjh9714/dsh-win32

### DIFF
--- a/catalog/plugins/sjh9714--dsh-win32.json
+++ b/catalog/plugins/sjh9714--dsh-win32.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "sjh9714/dsh-win32",
+  "name": "dsh-win32",
+  "repository": "https://github.com/sjh9714/dsh-win32",
+  "category": "tools",
+  "description": {
+    "en": "Supplies the win32 process inspector that DSH's Minimal preset needs, so the persistent shell starts on Windows instead of failing with terminal inspection is unsupported on platform win32. Ships a busybox-w32 preset variant whose shell also runs under the workspace-write restricted token, where MSYS shells die at cygheap init.",
+    "zh": "补上 DSH 极简预设所需的 win32 进程检查器，使持久 shell 在 Windows 上可用，不再报 terminal inspection is unsupported on platform win32。另带 busybox-w32 预设变体，其 shell 在 workspace-write 受限令牌下同样可运行，而 MSYS 系 shell 在该令牌下死于 cygheap 初始化。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
One new `catalog/plugins/*.json`, nothing else touched.

Checked against CONTRIBUTING before opening.

1. `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`) and that patch file is committed.
2. Published to npm as `dsh-win32` with `repository.url` pointing back here, so the npm install path is the documented one. Current 0.13.2.
3. The `dsh-plugin` topic is set.
4. Filename follows the id rule, `sjh9714/dsh-win32` becomes `sjh9714--dsh-win32.json`.
5. Descriptions state what it does and name the exact error it removes, with no superlatives.
6. `added` is today.
7. Only that one file is in the diff.

Tested by the author. windows-latest CI runs the persistent-shell round trip on every push, including one job that exercises the busybox variant under the `workspace-write` restricted token and reproduces the MSYS failure on the same path as a control.