### PR TITLE
catalog: add sjh9714/dsh-what-changed

### DIFF
--- a/catalog/plugins/sjh9714--dsh-what-changed.json
+++ b/catalog/plugins/sjh9714--dsh-what-changed.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "sjh9714/dsh-what-changed",
+  "name": "dsh-what-changed",
+  "repository": "https://github.com/sjh9714/dsh-what-changed",
+  "category": "session",
+  "description": {
+    "en": "Lists every file the agent wrote during a session from the session header, with per-file hunks, counting writes the permission layer refused separately from edits. A second section compares the workspace against HEAD, so files changed through shell commands rather than the write tools are also listed.",
+    "zh": "在会话顶栏列出本次会话 Agent 写过的所有文件与逐处改动，被权限层拒绝的写入与实际编辑分开计数。另有一节将工作区与 HEAD 对照，因此通过 shell 命令而非写入工具改动的文件同样会列出。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
One new `catalog/plugins/*.json`, nothing else touched.

Checked against CONTRIBUTING before opening.

1. `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`) and that patch file is committed.
2. Published to npm as `dsh-what-changed`, current 0.4.0, so the entry point ships built rather than being produced only at publish time.
3. The `dsh-plugin` topic is set.
4. Filename follows the id rule, `sjh9714/dsh-what-changed` becomes `sjh9714--dsh-what-changed.json`.
5. Descriptions are factual. The second sentence exists because the two sections genuinely answer different questions and the difference between them is the point.
6. `added` is today.
7. Only that one file is in the diff.

Tested by the author on dsh 0.1.0-rc.6. dshbase also install-tested it independently before listing.