### PR TITLE
catalog: add sjh9714/dsh-movein

### DIFF
--- a/catalog/plugins/sjh9714--dsh-movein.json
+++ b/catalog/plugins/sjh9714--dsh-movein.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "sjh9714/dsh-movein",
+  "name": "dsh-movein",
+  "repository": "https://github.com/sjh9714/dsh-movein",
+  "category": "tools",
+  "description": {
+    "en": "Moves an existing Claude Code or Codex CLI setup into DSH in one command, covering skills, slash commands, MCP servers, hooks, subagents and permission rules, with a dry run by default and a doctor command that checks the result afterwards.",
+    "zh": "一条命令把已有的 Claude Code 或 Codex CLI 配置迁入 DSH，涵盖技能、斜杠命令、MCP 服务器、hooks、子代理与权限规则，默认先执行 dry run，并提供 doctor 命令在迁移后检查结果。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
One new `catalog/plugins/*.json`, nothing else touched.

The catalog currently holds `sjh9714/dsh-movein/plugin` (the `dsh-movein-permissions` subpackage) but not the repository-level plugin it ships alongside. This adds the root id. Per CONTRIBUTING one repository may contribute several entries as long as each id is unique, and these two are different plugins: the subpackage is a standalone permission gate, the root is the migration tool.

Checked against CONTRIBUTING before opening.

1. Root `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`) and that patch file is committed.
2. Published to npm as `dsh-movein`, current 0.6.0.
3. The `dsh-plugin` topic is set.
4. Filename follows the id rule, `sjh9714/dsh-movein` becomes `sjh9714--dsh-movein.json`.
5. Descriptions are factual and name what is actually migrated.
6. `added` is today.
7. Only that one file is in the diff.

Tested by the author.