### PR TITLE
catalog: add welsione/dsh-mmx-bridge

### DIFF
--- a/catalog/plugins/welsione--dsh-mmx-bridge.json
+++ b/catalog/plugins/welsione--dsh-mmx-bridge.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "welsione/dsh-mmx-bridge",
+  "name": "dsh-mmx-bridge",
+  "repository": "https://github.com/welsione/dsh-mmx-bridge",
+  "category": "tools",
+  "description": {
+    "en": "Adds one mmx_bridge model tool to DeepSeek Harness that dispatches describe, image, video, speech, music, cover, search and quota actions to the MiniMax mmx CLI; optionally takes over the built-in web_search and read_image tools; ships a built-in client bundle that renders inline audio/video players and a settings-page management card in the Web GUI.",
+    "zh": "为 DeepSeek Harness 注册单个 mmx_bridge 模型工具，把 describe、image、video、speech、music、cover、search、quota 动作分发到 MiniMax mmx CLI；可选接管内置的 web_search 与 read_image 工具；内置客户端增强会在 Web 界面渲染内联音视频播放器和设置页管理卡片。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## 摘要

将 [`welsione/dsh-mmx-bridge`](https://github.com/welsione/dsh-mmx-bridge) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`./cordis.patch.yml`
- 测试命令：`npm run check`（即 `node --check lib/index.js && node --check lib/client.js`）；插件已安装于本地 DSH `web` profile（`~/.dsh/profiles/web/node_modules/dsh-mmx-bridge`，v1.0.6），并在会话中实际调用 `mmx_bridge` 的 describe / image / video / speech / music / cover / search / quota 动作
- 测试结果：语法检查通过；`web` profile 中插件正常加载运行，各动作返回预期结果，内置客户端在 Web 界面渲染内联音视频播放器与设置页管理卡片

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
