### PR TITLE
catalog: add Rewmington/deskwhale-harness/packages/bundle/base

### DIFF
--- a/catalog/plugins/rewmington--deskwhale-harness--packages--bundle--base.json
+++ b/catalog/plugins/rewmington--deskwhale-harness--packages--bundle--base.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Rewmington/deskwhale-harness/packages/bundle/base",
+  "name": "DeskWhale (dsh-base)",
+  "repository": "https://github.com/Rewmington/deskwhale-harness",
+  "category": "fun",
+  "description": {
+    "en": "The dsh-base bundle of DeskWhale, a community fork of DeepSeek Harness that adds a transparent desktop-pet whale, frosted-glass window, and startup splash to the agent UI.",
+    "zh": "DeskWhale 的 dsh-base 插件包：基于 DeepSeek Harness 的社区版桌宠改造，为 Agent 界面加入透明桌宠鲸鱼、磨砂玻璃窗口与启动闪屏。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## 摘要

将 [`Rewmington/deskwhale-harness/packages/bundle/base`](https://github.com/Rewmington/deskwhale-harness) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`packages/bundle/base/package.json`
- 子目录：`packages/bundle/base`（安装为 `github:Rewmington/deskwhale-harness#path:packages/bundle/base`）
- Bundle patch：`packages/bundle/base/cordis.patch.yml`
- 测试命令：日常使用内置该 bundle 的 DeskWhale 桌面发行版（Windows，`DeepSeek Harness.exe` / `pnpm dsh web`）
- 测试结果：应用正常启动，桌宠、磨砂玻璃窗口、启动闪屏、审批/提问提醒等功能均正常

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书