### PR TITLE
catalog: update welsione/dsh-mmx-bridge

### DIFF
--- a/catalog/plugins/welsione--dsh-mmx-bridge.json
+++ b/catalog/plugins/welsione--dsh-mmx-bridge.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/welsione/dsh-mmx-bridge",
   "category": "tools",
   "description": {
-    "en": "Adds one mmx_bridge model tool to DeepSeek Harness that dispatches describe, image, video, speech, music, cover, search and quota actions to the MiniMax mmx CLI; optionally takes over the built-in web_search and read_image tools; ships a built-in client bundle that renders inline audio/video players and a settings-page management card in the Web GUI.",
-    "zh": "为 DeepSeek Harness 注册单个 mmx_bridge 模型工具，把 describe、image、video、speech、music、cover、search、quota 动作分发到 MiniMax mmx CLI；可选接管内置的 web_search 与 read_image 工具；内置客户端增强会在 Web 界面渲染内联音视频播放器和设置页管理卡片。"
+    "en": "Adds vision to text-only models: the mmx_bridge describe action and the optional read_image takeover transcribe images into text via the MiniMax VLM, alongside image, video, speech, music and cover generation plus search and quota actions; a built-in client bundle renders inline audio/video players and a settings-page management card in the Web GUI.",
+    "zh": "为纯文本模型添加视觉能力：mmx_bridge 的 describe 动作与可选 read_image 接管通过 MiniMax VLM 把图片转写为文字描述，同时提供 image、video、speech、music、cover 生成与 search、quota 动作；内置客户端增强在 Web 界面渲染内联音视频播放器与设置页管理卡片。"
   },
   "added": "2026-08-18"
 }


### PR DESCRIPTION
## 摘要

更新 [`welsione/dsh-mmx-bridge`](https://github.com/welsione/dsh-mmx-bridge) 的目录条目：简介改为突出「为纯文本模型添加视觉能力」——`describe` 动作与可选的 `read_image` 接管通过 MiniMax VLM 把图片转写为文字描述，并保留对 image / video / speech / music / cover 生成与 search / quota 动作的说明。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`./cordis.patch.yml`
- 测试命令：`npm run check`（即 `node --check lib/index.js && node --check lib/client.js`）；插件已安装于本地 DSH `web` profile（`~/.dsh/profiles/web/node_modules/dsh-mmx-bridge`，v1.0.6），并在会话中实际调用 describe / image / video / speech / music / cover / search / quota 动作
- 测试结果：语法检查通过；describe 与 read_image 对本地图片返回文字描述（MiniMax VLM），其余动作返回预期结果

## 目录提交确认

- [x] 本 PR 只修改一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 中英文简介中性且准确
- [x] 我理解这是对既有条目的更新：静态审查通过后不会自动合并，需要维护者人工审核后合并
