### PR TITLE
catalog: classify bowenliang123/dsh-context as UI

### DIFF
--- a/catalog/plugins/bowenliang123--dsh-context.json
+++ b/catalog/plugins/bowenliang123--dsh-context.json
@@ -3,7 +3,7 @@
   "id": "bowenliang123/dsh-context",
   "name": "dsh-context",
   "repository": "https://github.com/bowenliang123/dsh-context",
-  "category": "memory",
+  "category": "ui",
   "description": {
     "en": "Adds a Context Insight panel to the DeepSeek Harness web UI showing what the model's context window currently holds and how it evolved: composition against window size, per-request history, compaction and injection events, and message-level token counts.",
     "zh": "为 DeepSeek Harness 网页界面添加上下文洞察面板，展示模型上下文窗口当前的构成与演变过程：各部分占比与窗口大小对照、按请求的历史趋势、压缩与注入事件，以及消息级 token 统计。"


### PR DESCRIPTION
## Summary

Reclassify [`bowenliang123/dsh-context`](https://github.com/bowenliang123/dsh-context) from `memory` to `ui`.

## Why

The plugin's primary user value is a Context Insight panel, history visualization, context browser, and `/context` modal in the DeepSeek Harness web UI. It does not provide cross-session recall, persistent knowledge storage, vector retrieval, or another long-term memory capability.

The existing curated entry was manually assigned to `memory`. Curated categories take precedence over AI classifications and are excluded from the automatic classification queue, so the current data path cannot correct this mismatch by itself.

## Impact

After merge, the existing catalog sync workflow will reconcile the corrected curated category into D1, refresh the production snapshot, and regenerate the README projections. No direct D1 edit or Worker deployment is required.

## Validation

- `npm run catalog:sync -- --dry-run` (validated 357 entries)
- `npm run test:catalog-sync` (9 passed)
- `npm run test:plugin-review` (34 passed)
- `git diff --cached --check`
- Staged-diff privacy scan: no credentials, private paths, internal repository references, or unrelated files

Only `catalog/plugins/bowenliang123--dsh-context.json` is changed; generated README projections are intentionally untouched.
