### PR TITLE
Add SenmuuuuW/dsh-whale-report (DeepTrace) — tools category

### DIFF
--- a/catalog/plugins/senmuuuuw--dsh-whale-report.json
+++ b/catalog/plugins/senmuuuuw--dsh-whale-report.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "SenmuuuuW/dsh-whale-report",
+  "name": "dsh-whale-report",
+  "repository": "https://github.com/SenmuuuuW/dsh-whale-report",
+  "category": "tools",
+  "description": {
+    "en": "DeepTrace — read-only agent reports for DeepSeek Harness: daily/weekly/monthly/yearly/custom reports from session logs with deterministic insights (cost, tokens, retry, dangerous commands, secret scan), collaboration review, tool health, live provider balance, multi-period trends and hourly activity heatmap; PDF/PNG/HTML export.",
+    "zh": "深迹 DeepTrace — DeepSeek Harness 只读 Agent 报告插件：从会话日志生成日报/周报/月报/年报/自定义区间报告，含确定性洞察（成本、Token、重试、危险命令、密钥扫描）、协作复盘、工具健康、模型余额、多周期趋势与小时级活跃热力图；支持 PDF/PNG/HTML 导出。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
Add **DeepTrace (深迹)** to the catalog (category: `tools`).

- **What it is**: read-only agent reports for DeepSeek Harness — daily / 24h / weekly / monthly / yearly / custom ranges from session logs; deterministic insights (cost, tokens, retry storms, dangerous commands, secret scan), collaboration review (human × harness), tool health (call/result pairing, failure & latency profile), live provider balance (DeepSeek), multi-period trends with LIVE marking, hourly activity heatmap; PDF / PNG / HTML export.
- **Compliance**: public repo, `dsh-plugin` topic present, `dsh.bundle.patch` (`cordis.patch.yml`) committed on `main`, entry point `lib/index.js` committed (GitHub install verified — no build step required), rc.7 compatible.
- **Testing**: `pnpm typecheck` + `pnpm test` (128 tests) + `pnpm build` green; runtime verified on DSH 0.1.0-rc.7 (balance / collaboration / tool health / trends / heatmap / exports).

Only the single catalog entry file is touched in this PR.