### PR TITLE
Add SpookySandwich/dsh-plugin-smooth-stream (ui)

### DIFF
--- a/catalog/plugins/spookysandwich--dsh-plugin-smooth-stream.json
+++ b/catalog/plugins/spookysandwich--dsh-plugin-smooth-stream.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "SpookySandwich/dsh-plugin-smooth-stream",
+  "name": "dsh-plugin-smooth-stream",
+  "repository": "https://github.com/SpookySandwich/dsh-plugin-smooth-stream",
+  "category": "ui",
+  "description": {
+    "en": "Reveals assistant replies in fading paragraph batches instead of token-by-token output, with smooth scroll-follow while streaming and a live one-line summary on reasoning blocks. Respects prefers-reduced-motion.",
+    "zh": "以淡入的段落批次呈现助手回复，而非逐字输出；流式过程中平滑跟随滚动，思考块显示实时单行摘要，并遵循 prefers-reduced-motion。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## Plugin

https://github.com/SpookySandwich/dsh-plugin-smooth-stream — replaces the Web UI's assistant-step rendering to reveal replies in fading paragraph batches instead of token-by-token output, with smooth scroll-follow while streaming and a live one-line summary on reasoning blocks. `prefers-reduced-motion` is respected.

## Author verification

- `dsh --profile web --dump-config` on dsh `0.1.0-rc.6` with the plugin installed composes the profile and lists the plugin's patch layer (`id: smooth-stream`).
- Verified live in the Web UI (`dsh web`): batched reveal, reasoning summary ticker and scroll-follow active during a streaming turn; markdown renders through the host `MarkdownText`.
- `lib/client.js` (the client entry) is committed, so a GitHub install ships runnable files. Also published on npm as `dsh-plugin-smooth-stream@1.0.1` with `repository.url` pointing back at this repository.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically
