### PR TITLE
Add nodata404/dsh-env-probe to catalog

### DIFF
--- a/catalog/plugins/nodata404--dsh-env-probe.json
+++ b/catalog/plugins/nodata404--dsh-env-probe.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "nodata404/dsh-env-probe",
+  "name": "dsh-env-probe",
+  "repository": "https://github.com/nodata404/dsh-env-probe",
+  "category": "tools",
+  "description": {
+    "en": "Probes the local machine environment (OS, shells, runtimes, tools, disks, proxy) once at startup, caches the report on disk, and injects it into every session's system prompt; registers /env-refresh and /env-suggest slash commands when a command adapter is available.",
+    "zh": "启动时探测一次本机环境（操作系统、Shell、运行时、常用工具、磁盘、代理），把报告缓存到磁盘并注入每个会话的系统提示词；在组合了命令适配器时注册 /env-refresh 与 /env-suggest 斜杠命令。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## 摘要

将 [`nodata404/dsh-env-probe`](https://github.com/nodata404/dsh-env-probe) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`（`dsh.bundle.patch` 指向该文件，已随仓库提交）
- 测试命令：`node --check index.js`；全新临时目录中 `npm install github:nodata404/dsh-env-probe` 后 `node --input-type=module -e "const m = await import('dsh-env-probe'); console.log(Object.keys(m))"`
- 测试结果：语法检查通过；git 安装成功（added 1 package），入口导出 `apply, inject, name, Config, probeEnvironment`；作者日常 dsh 会话中系统提示词持续注入 `ENV-PROBE` 本机环境档案段（探测时间 2026-08-18，Windows 环境实测）

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
