### PR TITLE
Add nirvanaslash/dsh-artifact-preview to catalog

### DIFF
--- a/catalog/plugins/nirvanaslash--dsh-artifact-preview.json
+++ b/catalog/plugins/nirvanaslash--dsh-artifact-preview.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "nirvanaslash/dsh-artifact-preview",
+  "name": "dsh-artifact-preview",
+  "repository": "https://github.com/nirvanaslash/dsh-artifact-preview",
+  "category": "ui",
+  "description": {
+    "en": "In-chat produced-files row with inline image thumbnails and a resizable side preview panel for Markdown, source code, CSV, JSON, images and HTML.",
+    "zh": "对话内产物文件行（含图片缩略图）与可拖宽的分屏侧边预览面板，支持 Markdown、源代码、CSV、JSON、图片与 HTML 渲染。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
Single new catalog entry for nirvanaslash/dsh-artifact-preview (category: ui). The plugin declares dsh.bundle.patch (./cordis.patch.yml, committed) and dsh.client for the web surface; built lib/ artifacts are committed.