### PR TITLE
catalog: add bobostudio/dsh-session-lens

### DIFF
--- a/catalog/plugins/bobostudio--dsh-session-lens.json
+++ b/catalog/plugins/bobostudio--dsh-session-lens.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "bobostudio/dsh-session-lens",
+  "name": "dsh-session-lens",
+  "repository": "https://github.com/bobostudio/dsh-session-lens",
+  "category": "session",
+  "description": {
+    "en": "Session insights and shareable single-file HTML replay for DeepSeek Harness: five-part token breakdown, per-turn timeline, tool statistics, with privacy-first redaction and a zero-JavaScript offline export.",
+    "zh": "DeepSeek Harness 会话洞察与分享插件：token 五段分解、按 Turn 时间线、工具统计；导出零 JavaScript 的自包含单文件 HTML 回放，隐私优先脱敏。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## Plugin

Repository: [bobostudio/dsh-session-lens](https://github.com/bobostudio/dsh-session-lens)

`dsh-session-lens` adds an Insights tab to any conversation in the DSH Web client. It aggregates the session event stream into a live analytics view: a five-part token breakdown (input / output / cache read / cache write / chain-of-thought), a per-turn timeline (duration, tokens, tool calls, errors), and tool statistics (call count, error rate, wall-clock time). It also exports the session as a self-contained single-file HTML replay — zero JavaScript, inline SVG charts, native <details> collapsibles, CSP default-src 'none', path redaction, and no system prompts — that opens offline and can be shared as one file.

## Author verification

Commands and results used to test behavior and compatibility:

npm run check      # tsc --noEmit: passed
npm run build      # esbuild bundles src/ → lib/ (Node half + client half): passed
npm test           # 41 unit/integration tests: all passed (node:test)

dsh web --patch <repo>/cordis.patch.yml   # local dev mount
# → opened http://127.0.0.1:17893/, loaded a real session,
#    Insights tab rendered token breakdown / per-turn timeline / tool stats,
#    exported single-file HTML opened offline (see README screenshots).

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically