### PR TITLE
catalog: add qweqwe12382/dsh-client-ui-pet (Q pet overlay)

### DIFF
--- a/catalog/plugins/qweqwe12382--dsh-client-ui-pet.json
+++ b/catalog/plugins/qweqwe12382--dsh-client-ui-pet.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "qweqwe12382/dsh-client-ui-pet",
+  "name": "dsh-client-ui-pet",
+  "repository": "https://github.com/qweqwe12382/dsh-client-ui-pet",
+  "category": "fun",
+  "description": {
+    "en": "Floating Q pet for the DSH Web UI: frame-atlas animation driven by the agent's session activity (thinking / reading / editing / working / replying / done / error), with rotating speech bubbles and in-session character switching.",
+    "zh": "DSH Web 界面的 Q 桌宠：帧图集动画随会话活动切换（思考 / 查阅 / 编辑 / 工作 / 回复 / 完成 / 出错），轮换对话气泡，支持角色切换。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
Adds the Q pet overlay plugin to the catalog.

- id: qweqwe12382/dsh-client-ui-pet
- category: fun
- Frame-atlas desktop pet following session activity with speech bubbles and character switching.

Verified: package.json declares dsh.bundle.patch -> ./cordis.patch.yml (committed); dsh-plugin topic added.