### PR TITLE
Add bpc-oss/dsh-routed-subagent to catalog

### DIFF
--- a/catalog/plugins/bpc-oss--dsh-routed-subagent.json
+++ b/catalog/plugins/bpc-oss--dsh-routed-subagent.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "bpc-oss/dsh-routed-subagent",
+  "name": "dsh-routed-subagent",
+  "repository": "https://github.com/bpc-oss/dsh-routed-subagent",
+  "category": "tools",
+  "description": {
+    "en": "Dispatch a one-shot subagent fully mounted on ANY agent preset from ANY session, with per-call model/provider override and a model-availability pre-check.",
+    "zh": "任意会话按指定 agent preset 与模型派一次性子代理（完整挂载 persona/技能/工具），带模型可用性预检。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
Adds [dsh-routed-subagent](https://github.com/bpc-oss/dsh-routed-subagent) to the catalog (category: tools). One new file: `catalog/plugins/bpc-oss--dsh-routed-subagent.json` per the contribution guide. The plugin declares `dsh.bundle.patch` (committed `cordis.patch.yml`) and carries the `dsh-plugin` topic.