### PR TITLE
catalog: add y2zyyr/dsh-model-retry-settings

### DIFF
--- a/catalog/plugins/y2zyyr--dsh-model-retry-settings.json
+++ b/catalog/plugins/y2zyyr--dsh-model-retry-settings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "y2zyyr/dsh-model-retry-settings",
+  "name": "dsh-model-retry-settings",
+  "repository": "https://github.com/y2zyyr/dsh-model-retry-settings",
+  "category": "ui",
+  "description": {
+    "en": "Adds a global \"Maximum model request retries\" setting (0/1/2/3/5/10, default 2) to Settings > General in DeepSeek Harness; the runtime honors it for every normal-mode provider retry policy. Pure plugin, install is behavior-neutral.",
+    "zh": "在 DeepSeek Harness 设置 > 通用中新增全局的「模型请求最大重试次数」选项（0/1/2/3/5/10，默认 2），运行时对 normal 模式的 provider 重试策略生效。纯插件实现，安装后行为不变。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
## Plugin

**y2zyyr/dsh-model-retry-settings** — Configurable model-request retry limit for DeepSeek Harness (Settings → General).

- npm: `@y2zyyr/dsh-model-retry-settings@1.0.0`
- repository: https://github.com/y2zyyr/dsh-model-retry-settings (public, topic `dsh-plugin`)
- license: MIT

## Verification

- `dsh.bundle.patch` declared in package.json → `cordis.patch.yml` committed in repo (verified).
- Package installs from npm (published @1.0.0, repository.url matches, no install/prepare lifecycle scripts).
- Tests run locally: `node --test test/*.test.mjs` — PASS (23/23: normalizer matrix, policy override, undefined/always passthrough, real Cordis + real dsh-llm-retry integration, client remount regression).
- `npm run build` and `npx tsc --noEmit` PASS.
- Runtime smoke: loaded in DSH Desktop web profile; Settings → General row renders 0/1/2/3/5/10 and persists into settings.yaml; runtime honors the value via the plugin-owned host route.

No unrelated files changed.
