### PR TITLE
catalog: add y2zyyr/dsh-restart-button

### DIFF
--- a/catalog/plugins/y2zyyr--dsh-restart-button.json
+++ b/catalog/plugins/y2zyyr--dsh-restart-button.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "y2zyyr/dsh-restart-button",
+  "name": "dsh-restart-button",
+  "repository": "https://github.com/y2zyyr/dsh-restart-button",
+  "category": "ui",
+  "description": {
+    "en": "One-click Restart DSH button in Settings > General for DeepSeek Harness Desktop, using the official desktopRuntime.requestRestart() graceful restart facade (no shell/kill/sudo), with native confirmation, single-flight protection and zh/en i18n.",
+    "zh": "在 DeepSeek Harness Desktop 设置 > 通用中添加一键「重启 DSH」按钮，通过官方 desktopRuntime.requestRestart() 优雅重启接口实现（无 shell/kill/sudo），含原生确认弹窗、防重复触发与中英文文案。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
## Plugin

**y2zyyr/dsh-restart-button** — One-click Restart DSH button for DSH Desktop (Settings → General).

- npm: `@y2zyyr/dsh-restart-button@0.1.0`
- repository: https://github.com/y2zyyr/dsh-restart-button (public, topic `dsh-plugin`)
- license: MIT

## Verification

- `dsh.bundle.patch` declared in package.json → `cordis.patch.yml` committed in repo (verified).
- Package installs from npm (published @0.1.0, repository.url matches, no install/prepare lifecycle scripts).
- Tests run locally: `node --test 'test/*.test.mjs'` — PASS (3/3: host bundle exports apply(), no shell/kill/sudo ops, restart route calls desktopRuntime.requestRestart → 202).
- `npm run build` and `npx tsc --noEmit` PASS.
- Uses the official `desktopRuntime.requestRestart()` graceful restart facade; no shell/kill/sudo.

No unrelated files changed.
