### PR TITLE
catalog: add Winter-And-You-Gone/dsh-turn-fold

### DIFF
--- a/catalog/plugins/winter-and-you-gone--dsh-turn-fold.json
+++ b/catalog/plugins/winter-and-you-gone--dsh-turn-fold.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Winter-And-You-Gone/dsh-turn-fold",
+  "name": "dsh-turn-fold",
+  "repository": "https://github.com/Winter-And-You-Gone/dsh-turn-fold",
+  "category": "ui",
+  "description": {
+    "en": "Automatically groups and collapses tool calls by Think segment, and folds each completed turn into a single header showing elapsed time, token usage, tokens-per-second, and cache-hit rate.",
+    "zh": "按 Think 段自动分组折叠工具调用；回合结束后把整回合收成一个组头，显示耗时、token、tok/s 与缓存命中率。"
+  },
+  "added": "2026-08-18"
+}


### PR DESCRIPTION
## 摘要

将 [`Winter-And-You-Gone/dsh-turn-fold`](https://github.com/Winter-And-You-Gone/dsh-turn-fold) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`dsh plugin add --save-exact dsh-turn-fold@0.2.2`（DSH Desktop 内安装验证）
- 测试结果：已在 DSH Desktop 中安装并验证自动折叠功能正常；npm 包 `dsh-turn-fold@0.2.2` 已发布并确认 `repository` 回链

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
