### PR TITLE
Add dsh-todolist plugin

### DIFF
--- a/catalog/plugins/hz-jasonlin--dsh-todolist.json
+++ b/catalog/plugins/hz-jasonlin--dsh-todolist.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "HZ-JasonLin/dsh-todolist",
+  "name": "dsh-todolist",
+  "repository": "https://github.com/HZ-JasonLin/dsh-todolist",
+  "category": "tools",
+  "description": {
+    "en": "An independent todo board for DeepSeek Harness: list, board, calendar, week and project views, AI tools (todolist / todolist_suggest), and a self-contained local storage backend.",
+    "zh": "DSH 独立待办看板：列表、看板、日历、周视图与项目视图，提供 todolist / todolist_suggest 两个 AI 工具，使用自建本地存储，不依赖其他插件。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
## Plugin

Link the submitted plugin repository and summarize its user-visible capability.

## Author verification

List the real command and result used to test plugin behavior and compatibility. The catalog workflow does not execute third-party plugin code.

## Catalog submissions

- [ ] This PR only touches `catalog/plugins/*.json` files
- [ ] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [ ] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [ ] Plugin behavior and compatibility were tested by the author
- [ ] `dsh-plugin` topic added
- [ ] English and Chinese descriptions are neutral and accurate
- [ ] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically
