### PR TITLE
Add xiaoliang2 dsh-compact-after-task plugin

### DIFF
--- a/catalog/plugins/xiaoliang2--dsh-compact-after-task.json
+++ b/catalog/plugins/xiaoliang2--dsh-compact-after-task.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "xiaoliang2/dsh-compact-after-task",
+  "name": "dsh-compact-after-task",
+  "repository": "https://github.com/xiaoliang2/dsh-compact-after-task",
+  "category": "workflow",
+  "description": {
+    "en": "Automatically compacts the conversation context after the current task completes, when context usage reaches a user-configurable ratio of the model's context window (0.05-1.0, default 0.5), adjustable via a toggle and slider on the settings page.",
+    "zh": "当前任务执行完成后自动压缩会话上下文：当上下文占用达到模型上下文窗口的用户可配置比例（0.05-1，默认 0.5）时触发，可在设置页通过开关与滑块调整。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
## 摘要

将 [`xiaoliang2/dsh-compact-after-task`](https://github.com/xiaoliang2/dsh-compact-after-task) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`node test-compact-after-task.mjs`
- 测试结果：`ALL TESTS PASSED`

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书