### PR TITLE
catalog: add kittsai/dsh-sidechat

### DIFF
--- a/catalog/plugins/kittsai--dsh-sidechat.json
+++ b/catalog/plugins/kittsai--dsh-sidechat.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "kittsai/dsh-sidechat",
+  "name": "dsh-sidechat",
+  "repository": "https://github.com/kittsai/dsh-sidechat",
+  "category": "ui",
+  "description": {
+    "en": "Side chat panel for the DeepSeek Harness web GUI: hover the browser's right edge to open a chat column alongside the main conversation, with streaming replies, collapsible reasoning, markdown tables, and in-panel model/effort switching.",
+    "zh": "面向 DeepSeek Harness Web GUI 的侧边聊天面板：鼠标悬停浏览器右边缘即打开与主对话并排的聊天栏，支持流式输出、可折叠思考过程、Markdown 表格，以及面板内切换模型与推理等级。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
## 摘要

将 [`kittsai/dsh-sidechat`](https://github.com/kittsai/dsh-sidechat) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`./cordis.patch.yml`
- 测试命令：`pnpm dsh plugin --profile web add github:kittsai/dsh-sidechat`，重启 `dsh web` 加载插件（构建产物已提交，安装时不运行构建脚本）
- 测试结果：插件经 GitHub 安装并加载成功，侧边聊天面板悬停呼出与流式回复正常工作；完整功能见仓库 README

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
