### PR TITLE
catalog: add ZHI-QI/dsh-okf-memory

### DIFF
--- a/catalog/plugins/zhi-qi--dsh-okf-memory.json
+++ b/catalog/plugins/zhi-qi--dsh-okf-memory.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ZHI-QI/dsh-okf-memory",
+  "name": "dsh-okf-memory",
+  "repository": "https://github.com/ZHI-QI/dsh-okf-memory",
+  "category": "memory",
+  "description": {
+    "en": "OKF v0.1 knowledge memory driven by cognitive-neuroscience principles: predictive recall (predict-then-verify), uncertainty-driven exploration, prediction-error capture (user corrections / first disclosures trigger writes), and a reinforcement feedback loop (score = relevance x weight x recency) with weight decay and archiving. TechChoice type distills frontend/backend/language selections into candidate tables with a three-tier choice rule; every concept is standard OKF Markdown (type-required frontmatter, index/log, cross-links).",
+    "zh": "由认知神经科学原理驱动的 OKF v0.1 知识记忆：预测性唤起（先预测再检索校验）、不确定性驱动探索、预测误差驱动捕获（用户纠正/首次披露自动触发写入）、强化反馈回路（score = relevance x weight x recency）与权重衰减归档。TechChoice 类型把前端/后端/语言选型沉淀为候选表并按三档选择规则唤起；所有概念均为标准 OKF Markdown（type 必填 frontmatter、index/log、交叉链接）。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
Add curated entry for ZHI-QI/dsh-okf-memory (category: memory).

- id: ZHI-QI/dsh-okf-memory (repository-level)
- package.json declares non-empty dsh.bundle.patch (./cordis.patch.yml), patch file committed
- entry point lib/index.js is committed source (no build artifact), installs cleanly from GitHub
- GitHub topic dsh-plugin added for tokenless metric discovery
- verified: 19 smoke checks + 24 mock-ctx integration checks + schema additionalProperties audit pass