### PR TITLE
docs: update dsh-vision-toolkit description

### DIFF
--- a/catalog/plugins/anionex--dsh-vision-toolkit.json
+++ b/catalog/plugins/anionex--dsh-vision-toolkit.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/Anionex/dsh-vision-toolkit",
   "category": "tools",
   "description": {
-    "en": "Vision tasks for text-only models: intent-aware image Q&A, long-screenshot OCR, UI reproduction, grounding, and pixel diff.",
-    "zh": "让纯文本模型更好地做视觉任务：带意图的图片问答、长截图 OCR、UI 还原等。"
+    "en": "One-command install and free to use; paste an image to see and ask. Provides a nearly seamless multimodal experience for text-only models, supporting image Q&A, multi-image comparison, long-screenshot OCR, screenshot-to-UI restoration, element grounding, pixel diff, and more.",
+    "zh": "一键安装、免费使用；粘贴图片即可看图问答。为纯文本模型提供近乎无缝的多模态体验，支持图片问答、多图比较、长图 OCR、截图到前端 UI 还原、元素定位、像素对比等。"
   },
   "added": "2026-08-13"
 }


### PR DESCRIPTION
## Plugin

Update the catalog entry for [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) — a vision toolkit for text-only DeepSeek Harness models (image Q&A, long-screenshot OCR, screenshot-to-UI restoration, grounding, pixel diff). This PR only refreshes the existing entry English and Chinese descriptions; no plugin code changes.

## Author verification

Plugin behavior is unchanged by this catalog-only PR. The plugin repository verification baseline is `CI=true pnpm install` -> `CI=true pnpm build` -> `node_modules/.bin/vitest run` (300 passed / 1 skipped), and the plugin has been used against DSH 0.1.0-rc.6/rc.7 in Web and Headless profiles.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically