### PR TITLE
catalog: add kiligzzz/dsh-session-archive

### DIFF
--- a/catalog/plugins/kiligzzz--dsh-session-archive.json
+++ b/catalog/plugins/kiligzzz--dsh-session-archive.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "kiligzzz/dsh-session-archive",
+  "name": "dsh-session-archive",
+  "repository": "https://github.com/kiligzzz/dsh-session-archive",
+  "category": "session",
+  "description": {
+    "en": "Sidebar panel for archived sessions in DeepSeek Harness: group by workspace, search by title, preview user questions, one-click restore, or delete with confirmation.",
+    "zh": "DeepSeek Harness 已归档会话管理面板：按工作区目录分组、按标题实时搜索、只读预览用户问题、一键恢复，或二次确认后删除。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
Add a catalog entry for [kiligzzz/dsh-session-archive](https://github.com/kiligzzz/dsh-session-archive): a DeepSeek Harness web plugin that surfaces the registry-global archived-session set — grouped panel, live title search, read-only preview, one-click restore, and delete with confirmation.

- category: `session`
- declares `dsh.bundle.patch` in package.json, patch file committed
- added `dsh-plugin` topic