### PR TITLE
Add dream-num/dsh-univer-office to catalog

### DIFF
--- a/catalog/plugins/dream-num--dsh-univer-office.json
+++ b/catalog/plugins/dream-num--dsh-univer-office.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "dream-num/dsh-univer-office",
+  "name": "dsh-univer-office",
+  "repository": "https://github.com/dream-num/dsh-univer-office",
+  "category": "tools",
+  "description": {
+    "en": "Create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases in DeepSeek Harness, with live preview and worktree review.",
+    "zh": "在 DeepSeek Harness 中创建、编辑、检查和交付表格、文档、演示文稿、多维表格和画布，支持实时预览与 worktree 审阅。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
# Add dream-num/dsh-univer-office to catalog

## Summary

Adds [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) to the plugin catalog.

## What it does

- Creates and edits Sheets, Docs, Slides, Bases, and Boards in `.univer` files.
- Imports `.xlsx`, `.csv`, `.tsv`, `.docx`, and `.pptx` files, and exports edited content back to the matching Office format.
- Verifies changes through structured readback, formula recalculation, and Slide layout checks.
- Uses isolated worktrees for every write; users can preview, merge, or discard changes from the conversation.
- Ships version-matched Skills and `univer_*` tools, plus a bundled Gateway, Viewer, and Unit Content Worker.

## Checklist

- [x] `package.json` declares `dsh.bundle.patch`
- [x] `dsh-plugin` GitHub topic enabled
- [x] Only added one new file: `catalog/plugins/dream-num--dsh-univer-office.json`
- [x] Category: `tools`
- [x] Both `description.en` and `description.zh` are factual and specific
- [x] Installable via `dsh plugin --profile web add dsh-univer-office`
