### PR TITLE
catalog: add ExElectron/dsh-gov-portal

### DIFF
--- a/catalog/plugins/exelectron--dsh-gov-portal.json
+++ b/catalog/plugins/exelectron--dsh-gov-portal.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ExElectron/dsh-gov-portal",
+  "name": "dsh-gov-portal",
+  "repository": "https://github.com/ExElectron/dsh-gov-portal",
+  "category": "ui",
+  "description": {
+    "en": "A DeepSeek Harness plugin that provides an independent government-service portal interface backed by the host apiProxy.",
+    "zh": "为 DeepSeek Harness 提供独立政务服务门户界面的插件，通过宿主 apiProxy 对接会话、模型、权限与统计能力。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
## Summary

Add `ExElectron/dsh-gov-portal` to the DeepSeek Harness plugin catalog.

## Plugin verification

- Manifest: `package.json`
- Bundle patch: `cordis.patch.yml`
- GitHub installation entry: `lib/index.js` is committed
- Repository topic: `dsh-plugin`
- License: MIT

## Author test evidence

```text
node test/server-smoke.mjs
```

Result: all smoke checks passed, covering static assets, API bridge dispatch, SSE framing, response handling, and session export.

## Change scope

This PR adds exactly one catalog entry: `catalog/plugins/exelectron--dsh-gov-portal.json`.