### PR TITLE
catalog: add UlaBe/dsh-conversation-nav

### DIFF
--- a/catalog/plugins/ulabe--dsh-conversation-nav.json
+++ b/catalog/plugins/ulabe--dsh-conversation-nav.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "UlaBe/dsh-conversation-nav",
+  "name": "dsh-conversation-nav",
+  "repository": "https://github.com/UlaBe/dsh-conversation-nav",
+  "category": "ui",
+  "description": {
+    "en": "DeepSeek web-style conversation navigation: a right-edge tick rail with a hover panel listing every user message, click to jump.",
+    "zh": "DS 网页版风格对话导航：右侧刻度条 + 悬停面板列出每条用户消息，点击跳转。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
## 摘要

将 [`UlaBe/dsh-conversation-nav`](https://github.com/UlaBe/dsh-conversation-nav) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`dsh plugin --profile web add @ulabe/dsh-conversation-nav`（本地开发时以 profile 的 node_modules symlink 指向源码仓库）
- 测试结果：在 http://127.0.0.1:3080 强刷后实测——右侧刻度条正常显示、蓝条高亮随滚动切换；hover 展开面板列出每条用户消息，点击跳转正常，自动分页加载全量历史；flat 版（v0.2.0）面板内为扁平消息列表，点击跳转正常。

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
