### PR TITLE
add dsh-agent-plugins-market to catalog

### DIFF
--- a/catalog/plugins/sivan757--dsh-agent-plugins-market.json
+++ b/catalog/plugins/sivan757--dsh-agent-plugins-market.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Sivan757/dsh-agent-plugins-market",
+  "name": "dsh-agent-plugins-market",
+  "repository": "https://github.com/Sivan757/dsh-agent-plugins-market",
+  "category": "tools",
+  "description": {
+    "en": "Bring Claude Code / Codex / Cursor plugin marketplaces into DeepSeek Harness: install and inject agent plugins — skills, MCP servers, hooks, slash commands — from git marketplace repos, with a Web GUI market page.",
+    "zh": "把 Claude Code / Codex / Cursor 插件市场生态带进 DeepSeek Harness：从 git 市场仓库安装并注入 Agent 插件（技能、MCP 服务器、hooks、斜杠命令），自带 Web 市场页。"
+  },
+  "added": "2026-08-19"
+}


### PR DESCRIPTION
Add [dsh-agent-plugins-market](https://github.com/Sivan757/dsh-agent-plugins-market): install & inject Claude Code / Codex / Cursor agent plugins (skills, MCP servers, hooks, slash commands) into DeepSeek Harness from git marketplace repos, with a Web GUI market page. Declares `dsh.bundle.patch` (cordis.patch.yml, committed); built entry point (`lib/`, `client/`) is committed so `github:` installs work; `dsh-plugin` topic set.