### PR TITLE
catalog: add Sandbase DSH Plugin Store

### DIFF
--- a/catalog/plugins/sandbaseai--dsh-plugin-store.json
+++ b/catalog/plugins/sandbaseai--dsh-plugin-store.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "sandbaseai/dsh-plugin-store",
+  "name": "dsh-plugin-store",
+  "repository": "https://github.com/sandbaseai/dsh-plugin-store",
+  "category": "ui",
+  "description": {
+    "en": "Native Settings marketplace with Community and Installed views, search, tag filters, local install feedback, and agent catalog tools.",
+    "zh": "原生 Settings 插件市场，提供 Community / Installed 双视图、搜索、Tag 筛选、本地安装反馈和 Agent 目录工具。"
+  },
+  "added": "2026-08-20"
+}


### PR DESCRIPTION
Adds one source-verified DSH plugin entry following the repository-level submission format.

Verification before submission:

- Root `package.json` declares `dsh.bundle.patch` and Web client injection metadata.
- `cordis.patch.yml` is committed at the declared path.
- Repository has the `dsh-plugin` topic.
- Host typecheck and Host/Web client bundle passed in the DeepSeek Harness `0.1.0-rc.5` workspace.
- This PR changes exactly one `catalog/plugins/*.json` file.

Preview release: https://github.com/sandbaseai/dsh-plugin-store/releases/tag/v0.1.0-preview.1