### PR TITLE
catalog: add xbyzzZ/dsh_token_usage

### DIFF
--- a/catalog/plugins/xbyzzz--dsh-token-usage.json
+++ b/catalog/plugins/xbyzzz--dsh-token-usage.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "xbyzzZ/dsh_token_usage",
+  "name": "dsh_token_usage",
+  "repository": "https://github.com/xbyzzZ/dsh_token_usage",
+  "category": "ui",
+  "description": {
+    "en": "Sidebar Usage action above Settings with a 30-day heatmap and per-model table from local session JSONL. Produced tokens are input + output + cache write; no estimates for sessions without usage.",
+    "zh": "在设置上方放用量入口，从本地会话 JSONL 汇总最近 30 天热力图和按模型表。新产生为 input + output + cache write，没有 usage 的会话不估算。"
+  },
+  "added": "2026-08-20"
+}


### PR DESCRIPTION
## 摘要

将 [`xbyzzZ/dsh_token_usage`](https://github.com/xbyzzZ/dsh_token_usage) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`node --test test/*.test.js`
- 测试结果：8 tests pass

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书