### PR TITLE
catalog: add q35888/dsh-plugin-browser

### DIFF
--- a/catalog/plugins/q35888--dsh-plugin-browser.json
+++ b/catalog/plugins/q35888--dsh-plugin-browser.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "q35888/dsh-plugin-browser",
+  "name": "dsh-plugin-browser",
+  "repository": "https://github.com/q35888/dsh-plugin-browser",
+  "category": "tools",
+  "description": {
+    "en": "Adds 15 browser_* tools (navigate, snapshot with element refs, click, type, select, hover, tabs, dialog handling, eval, storage, console, screenshot, human-in-the-loop wait) that drive a logged-in Chrome via Playwright over CDP, with automatic Chrome launch and windowless-zombie self-healing.",
+    "zh": "提供 15 个 browser_* 工具(导航、带元素 ref 的快照、点击、输入、下拉选择、悬停、标签页管理、弹窗处理、eval、存储、控制台、截图、人工确认等待),通过 Playwright 经 CDP 驱动已登录的 Chrome,支持自动拉起 Chrome 与无窗口僵尸态自愈。"
+  },
+  "added": "2026-08-20"
+}


### PR DESCRIPTION
## 摘要

将 [`q35888/dsh-plugin-browser`](https://github.com/q35888/dsh-plugin-browser) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`node --check index.js`；`node smoke-test`(mock ctx 注册断言 + 真实 CDP 链路：session→navigate→snapshot→ref 点击→eval→close)；`node windowless-revive-test`(复现无窗口僵尸 Chrome 后验证自愈)
- 测试结果：全部通过——15 个工具注册与参数 schema 校验(example.com 导航/快照/点击/ref 失效恢复路径)、无窗口僵尸态端到端 0.5s 自愈；并已在 DSH Desktop 实际会话中验证(navigate/eval 及 browser_wait_human 人工确认卡片往返)

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书