### PR TITLE
catalog: add CMSKL/dsh-plugin-observatory

### DIFF
--- a/catalog/plugins/cmskl--dsh-plugin-observatory.json
+++ b/catalog/plugins/cmskl--dsh-plugin-observatory.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "CMSKL/dsh-plugin-observatory",
+  "name": "dsh-plugin-observatory",
+  "repository": "https://github.com/CMSKL/dsh-plugin-observatory",
+  "category": "dev",
+  "description": {
+    "en": "Provides bounded static compatibility audits for local DSH plugin manifests and bundle patches, plus process-local Loader lifecycle observation.",
+    "zh": "为本地 DSH 插件清单与 bundle patch 提供有界静态兼容性审计，并观测进程内 Loader 生命周期。"
+  },
+  "added": "2026-08-20"
+}


### PR DESCRIPTION
## 摘要

将 [`CMSKL/dsh-plugin-observatory`](https://github.com/CMSKL/dsh-plugin-observatory) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`pnpm run check && pnpm run test:coverage && pnpm run publint && pnpm pack --dry-run && pnpm run test:e2e`
- 测试结果：全部通过；23 项测试通过，覆盖率 statements 97.47%、branches 91.9%、functions 100%、lines 99.16%，publint 与 pack dry-run 通过，DSH 0.1.0-rc.6 隔离 profile 安装、启动和卸载 E2E 通过。

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书