### PR TITLE
catalog: describe direct chain-edit (image-to-image without re-upload)

### DIFF
--- a/catalog/plugins/github-cjx--dsh-tool-imagegen.json
+++ b/catalog/plugins/github-cjx--dsh-tool-imagegen.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/Github-CJX/dsh-tool-imagegen",
   "category": "tools",
   "description": {
-    "en": "OpenAI-compatible image generation in DSH Desktop chat: generate inline, upload or one-click edit reference images (image-to-image), with storage cleanup.",
-    "zh": "对话内联生图插件：模型在对话框直接出图，上传参考图即可图生图连续修改，附存储清理。"
+    "en": "OpenAI-compatible image generation in DSH Desktop chat: generate inline, edit reference images or chain-edit previous results directly (image-to-image) without re-uploading, with storage cleanup.",
+    "zh": "对话内联生图插件：模型在对话框直接出图，可基于参考图或上次生成结果连续图生图修改，附存储清理。"
   },
   "added": "2026-08-20"
 }


### PR DESCRIPTION
zh：对话内联生图插件：模型在对话框直接出图，可基于参考图或上次生成结果连续图生图修改，附存储清理。
  ▎ en：OpenAI-compatible image generation in DSH Desktop chat: generate inline, edit reference images or chain-edit
  ▎ previous results directly (image-to-image) without re-uploading, with storage cleanup.