### PR TITLE
Add TapTap Maker DSH plugin

### DIFF
--- a/catalog/plugins/taptap--instant-games-open-mcp--packages--dsh-maker.json
+++ b/catalog/plugins/taptap--instant-games-open-mcp--packages--dsh-maker.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "taptap/instant-games-open-mcp/packages/dsh-maker",
+  "name": "dsh-maker",
+  "repository": "https://github.com/taptap/instant-games-open-mcp",
+  "category": "tools",
+  "description": {
+    "en": "Provides TapTap Maker MCP tools and bundled game-development skills for DeepSeek Harness.",
+    "zh": "为 DeepSeek Harness 提供 TapTap Maker MCP 工具和配套的游戏开发技能。"
+  },
+  "added": "2026-08-20"
+}


### PR DESCRIPTION
## Summary

- register the TapTap Maker DSH plugin from the monorepo subpackage
- point catalog installation to `packages/dsh-maker`
- provide English and Chinese marketplace descriptions

## Verification

- `npm run plugin:review` (VERDICT auto-merge)
- `npm run test:plugin-review` (35 tests passed)