### PR TITLE
Add my-image-drop to the catalog

### DIFF
--- a/catalog/plugins/yangpeng-space--my-image-drop.json
+++ b/catalog/plugins/yangpeng-space--my-image-drop.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "yangpeng-space/my-image-drop",
+  "name": "my-image-drop",
+  "repository": "https://github.com/yangpeng-space/my-image-drop",
+  "category": "ui",
+  "description": {
+    "en": "Adds drag-and-drop of images into the DeepSeek Harness composer. Dropped images are stored as a private temp file and inserted as a file path, so text-only models can read them with the read tool instead of failing image admission.",
+    "zh": "为 DeepSeek Harness 输入框增加图片拖放能力。拖入的图片被存为私有临时文件并以文件路径形式插入输入框，让纯文本模型能用 read 工具读取，而不会触发图片准入失败。"
+  },
+  "added": "2026-08-20"
+}


### PR DESCRIPTION
# Add my-image-drop to the catalog

Add a new catalog entry for `yangpeng-space/my-image-drop`.

- Plugin ID: `yangpeng-space/my-image-drop`
- Repository: https://github.com/yangpeng-space/my-image-drop
- Category: `ui`
- Install: `dsh plugin add github:yangpeng-space/my-image-drop`

## Checklist

- [x] I am adding exactly one new `catalog/plugins/yangpeng-space--my-image-drop.json` file and no other catalog file.
- [x] The source repository is public and has a default branch.
- [x] The source manifest declares a non-empty `dsh.bundle.patch`, and that referenced file is committed on the default branch.
- [x] The source repository declares the `dsh-plugin` GitHub topic.
- [x] I have installed the source from GitHub into a compatible DSH runtime and tested its behavior, runtime, and compatibility.
- [x] The English and Chinese descriptions are factual, neutral, and specific.
- [x] I understand that the catalog project may maintain or merge this entry automatically without contacting me.

## Testing evidence

Author-tested. Installed the plugin into a web-profile DeepSeek Harness desktop runtime from the GitHub source, restarted the app, dragged a PNG into the composer, and confirmed a private temp file path was inserted as plain text and the `read` tool opened the file. Host route `POST /my-image-drop` magic-byte checks and size cap verified with a valid PNG (200 + path) and a non-image payload (400).

## Changed files

- `catalog/plugins/yangpeng-space--my-image-drop.json` (new)
