### PR TITLE
catalog: add bpc-oss/chrome-faithful

### DIFF
--- a/catalog/plugins/bpc-oss--chrome-faithful.json
+++ b/catalog/plugins/bpc-oss--chrome-faithful.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "bpc-oss/chrome-faithful",
+  "name": "chrome-faithful",
+  "repository": "https://github.com/bpc-oss/chrome-faithful",
+  "category": "tools",
+  "description": {
+    "en": "Control your real, logged-in Chrome profiles over MCP: exact multi-profile routing through an MV3 chrome.debugger extension and an authenticated localhost bridge. No copied profiles, no debug profile, no remote-debugging port, no Edge. Includes multi-signal challenge detection with humanized verification handling, page File injection, signed-URL-safe media export, and durable virtual-list capture.",
+    "zh": "通过 MCP 忠实控制你真实、已登录的 Chrome 配置文件：基于 MV3 chrome.debugger 扩展与经认证的本地桥接实现精确多 Profile 路由。不复制配置文件、不用调试 Profile、不开远程调试端口、不用 Edge。内置多信号挑战检测与人机化验证处理、页面 File 注入、签名 URL 安全的媒体导出，以及持久化虚拟列表采集。"
+  },
+  "added": "2026-08-20"
+}


### PR DESCRIPTION
Adds one catalog entry for **bpc-oss/chrome-faithful** (category: tools).

chrome-faithful is an MCP bridge for exact control of real, logged-in Chrome profiles: an MV3 chrome.debugger extension per profile plus an authenticated localhost bridge. It declares a DSH bundle manifest (`dsh.bundle.patch` → `cordis.patch.yml`); installing it into a profile mounts the MCP server through `@deepseek-ai/dsh-mcp-client` (stdio, serverName `chrome_faithful`), exposing the `chrome_*` tools as `mcp__chrome_faithful__*`.

Highlights: no copied profiles / no debug profile / no remote-debugging port / no Edge; multi-signal verification-challenge detection with humanized solving and handoff; page File injection; signed-URL-safe media export; durable virtual-list capture. The repository carries the `dsh-plugin` topic and a committed `cordis.patch.yml`.

Verified: the bundle installs into a scratch profile and the composed config contains the MCP row; the plugin repo passes `npm run check` and its 197 unit tests.