### PR TITLE
catalog: add ERVeepp/dsh-plugins/packages/tool-npm-advisor

### DIFF
--- a/catalog/plugins/erveepp--dsh-plugins--packages--tool-npm-advisor.json
+++ b/catalog/plugins/erveepp--dsh-plugins--packages--tool-npm-advisor.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ERVeepp/dsh-plugins/packages/tool-npm-advisor",
+  "name": "npm-advisor",
+  "repository": "https://github.com/ERVeepp/dsh-plugins",
+  "category": "tools",
+  "description": {
+    "en": "npm package adoption advisor for DeepSeek Harness: audits whether a candidate dependency is the best choice (native alternatives, maintenance health, README migration hints) and renders a dependency tree.",
+    "zh": "为 DeepSeek Harness 提供 npm 包引入前审查工具：判断候选依赖是否是最优解（原生替代、维护健康度、README 迁移线索），并生成依赖树。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
## 摘要

将 [`ERVeepp/dsh-plugins/packages/tool-npm-advisor`](https://github.com/ERVeepp/dsh-plugins) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`packages/tool-npm-advisor/package.json`
- 子目录：`packages/tool-npm-advisor`（安装为 `github:ERVeepp/dsh-plugins#path:packages/tool-npm-advisor`）
- Bundle patch：`packages/tool-npm-advisor/cordis.patch.yml`
- 测试命令：`pnpm typecheck && pnpm smoke && pnpm load-test`（在 dsh-plugins 仓库根）
- 测试结果：
  - `[OK] 注册的工具 = npm_package_audit, npm_dependency_tree`
  - `[PASS] 两个工具均注册成功，Cordis 加载链路正常`
  - smoke 用例：moment 命中「维护模式 + README 迁移线索」、axios 命中原生替代 `fetch`、依赖树输出 mermaid 正常

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
