### PR TITLE
catalog: add dsh-lcx-codex

### DIFF
--- a/catalog/plugins/kk3ya03-star--dsh-lcx-codex.json
+++ b/catalog/plugins/kk3ya03-star--dsh-lcx-codex.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "kk3ya03-star/dsh-lcx-codex",
+  "name": "dsh-lcx-codex",
+  "repository": "https://github.com/kk3ya03-star/dsh-lcx-codex",
+  "category": "tools",
+  "description": {
+    "en": "Adds capability-gated Hosted and Alpha web search plus Responses Native V2 compaction for Sub2API-proxied or NewAPI-relayed GPT models in DSH.",
+    "zh": "为 DSH 中经 Sub2API 反代或 NewAPI 中转的 GPT 模型提供按部署能力启用的 Hosted/Alpha 网页搜索与 Responses Native V2 压缩。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
## Plugin

https://github.com/kk3ya03-star/dsh-lcx-codex

Adds capability-gated Hosted and Alpha web search plus Responses Native V2 compaction for Sub2API-proxied or NewAPI-relayed GPT models in DSH. The plugin reuses the active DSH `openai-responses` provider route and credential, and is disabled by default.

## Author verification

- `npm test`: 104 tests, 100 passed, 0 failed, 4 credential-gated real endpoint tests skipped in this release run.
- `npm run test:schema`: all four Hosted/Alpha parameter and output schemas passed.
- Both README Mermaid diagrams parsed with Mermaid 11.12.
- `dsh-lcx-codex@0.3.1` was installed from the public npm registry in a clean temporary directory; the host entry and DSH Web client registration both imported successfully.
- Existing live acceptance was performed with DSH `0.1.0-rc.8` through a NewAPI `Sub2API` channel backed by Sub2API OAuth: Hosted Search, all ten Alpha actions, Native V2 compaction, checkpoint replay, restart, and route migration were exercised. No credentials or runtime artifacts are included in the repository.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically

## Maintainer API compatibility

Catalog-only submission; no marketplace API or application files are changed.

- [ ] This change has no API behavior impact, or its API impact is described above
- [ ] Every added or changed API route is registered in `apps/web/contracts/api-surface.json`
- [ ] Existing-version behavior remains backward compatible and historical contract fixtures were not casually rewritten
- [ ] Any breaking behavior uses a new versioned route while the previous version remains available
- [ ] `npm run test:api-contract` passes
