### PR TITLE
Add new plugin definition for cortiq-dsh-llm-router

### DIFF
--- a/catalog/plugins/infosave2007--cortiq-router--packages--dsh-llm-cortiq-router.json
+++ b/catalog/plugins/infosave2007--cortiq-router--packages--dsh-llm-cortiq-router.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "infosave2007/cortiq-router/packages/dsh-llm-cortiq-router",
+  "name": "cortiq-dsh-llm-router",
+  "repository": "https://github.com/infosave2007/cortiq-router",
+  "category": "llm-provider",
+  "description": {
+    "en": "Smart LLM request router. Classifies prompts by task type (code, math, translation, etc.) and complexity (low/medium/high) via the allaigate semantic router, then dispatches to the best-suited model. Configurable routing rules, complexity thresholds, 7 UI languages.",
+    "ru": "Умный маршрутизатор LLM-запросов. Классифицирует промпты по типу задачи и сложности через семантический роутер allaigate, затем направляет к оптимальной модели. Настраиваемые правила маршрутизации и пороги сложности.",
+    "zh": "智能LLM请求路由器。通过allaigate语义路由器按任务类型和复杂度分类提示词，然后分发到最合适的模型。可配置路由规则和复杂度阈值。"
+  },
+  "added": "2026-08-20"
+}

--- a/catalog/plugins/infosave2007--cortiq-router--packages--dsh-llm-cortiq-router.json
+++ b/catalog/plugins/infosave2007--cortiq-router--packages--dsh-llm-cortiq-router.json
@@ -3,11 +3,10 @@
   "id": "infosave2007/cortiq-router/packages/dsh-llm-cortiq-router",
   "name": "cortiq-dsh-llm-router",
   "repository": "https://github.com/infosave2007/cortiq-router",
-  "category": "llm-provider",
+  "category": "model",
   "description": {
     "en": "Smart LLM request router. Classifies prompts by task type (code, math, translation, etc.) and complexity (low/medium/high) via the allaigate semantic router, then dispatches to the best-suited model. Configurable routing rules, complexity thresholds, 7 UI languages.",
-    "ru": "Умный маршрутизатор LLM-запросов. Классифицирует промпты по типу задачи и сложности через семантический роутер allaigate, затем направляет к оптимальной модели. Настраиваемые правила маршрутизации и пороги сложности.",
-    "zh": "智能LLM请求路由器。通过allaigate语义路由器按任务类型和复杂度分类提示词，然后分发到最合适的模型。可配置路由规则和复杂度阈值。"
+    "zh": "智能LLM请求路由器。通过allaigate语义路由器按任务类型（代码、数学、翻译等）和复杂度（低/中/高）对提示词分类，然后分发到最合适的模型。可配置路由规则、复杂度阈值，支持7种界面语言。"
   },
   "added": "2026-08-20"
 }


### PR DESCRIPTION

**Plugin:** `cortiq-dsh-llm-router` — Smart LLM request router. Classifies prompts by task type (code, math, translation, etc.) and complexity (low/medium/high) via the allaigate semantic router, then dispatches to the best-suited model.

**Author verification:**

```
# Test 1: install plugin
npx -p @deepseek-ai/dsh dsh plugin --profile web add cortiq-dsh-llm-router
# Result: dependencies: + cortiq-dsh-llm-router ^0.1.3, Packages: +4, Done

# Test 2: routing table logic
node --input-type=module -e "
import { createRoutingTable } from 'cortiq-dsh-llm-router';
const rt = createRoutingTable({
  globalTiers: { low: ['flash'], medium: ['pro', 'flash'], high: ['pro'] },
  taskRules: { code: { low: ['fast'], high: ['best'] } },
  defaultModel: 'flash',
  complexityBands: { low: 0.35, medium: 0.65 },
});
console.log('code @ low:', rt.candidatesFor('code', 'low').models.join(' → '));
console.log('code @ high:', rt.candidatesFor('code', 'high').models.join(' → '));
"
# Result: code @ low: fast → flash
#         code @ high: best → pro → flash
```

**Catalog submissions:**

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [ ] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically

**Maintainer API compatibility:**

- [x] This change has no API behavior impact, or its API impact is described above
- [ ] Every added or changed API route is registered in `apps/web/contracts/api-surface.json`
- [ ] Existing-version behavior remains backward compatible and historical contract fixtures were not casually rewritten
- [ ] Any breaking behavior uses a new versioned route while the previous version remains available
- [ ] `npm run test:api-contract` passes
