### PR TITLE
Add dsh-claude plugin

### DIFF
--- a/catalog/plugins/norman-else--dsh-claude.json
+++ b/catalog/plugins/norman-else--dsh-claude.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Norman-else/dsh-claude",
+  "name": "dsh-claude",
+  "repository": "https://github.com/Norman-else/dsh-claude",
+  "category": "model",
+  "description": {
+    "en": "Runs the local Claude Code CLI as a DSH agent preset with session resume, permission bridging, activity presentation, and Claude Code skills, hooks, plugins, and MCP configuration.",
+    "zh": "将本地 Claude Code CLI 作为 DSH Agent Preset 运行，支持会话恢复、权限桥接、活动展示，以及 Claude Code 的 Skills、Hooks、Plugins 和 MCP 配置。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
## Summary
Add `Norman-else/dsh-claude` to the plugin catalog under the model integration category.

## Changes
- Added one catalog entry with factual English and Chinese descriptions.
- Referenced the repository-level DSH plugin and its existing bundle manifest.

## Verification
- Confirmed the repository has the `dsh-plugin` topic.
- Confirmed `package.json` declares `dsh.bundle.patch` and `cordis.patch.yml` exists.
- Compared the branch against `main`; only `catalog/plugins/norman-else--dsh-claude.json` was added.

Co-Authored-By: Warp <agent@warp.dev>

[Warp conversation](https://app.warp.dev/conversation/6ab1919d-58c8-42e0-9983-23ab7916e6fa)