### PR TITLE
catalog: add alone-tree/dsh-skill-mcp-manager

### DIFF
--- a/catalog/plugins/alone-tree--dsh-skill-mcp-manager.json
+++ b/catalog/plugins/alone-tree--dsh-skill-mcp-manager.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "alone-tree/dsh-skill-mcp-manager",
+  "name": "dsh-skill-mcp-manager",
+  "repository": "https://github.com/alone-tree/dsh-skill-mcp-manager",
+  "category": "tools",
+  "description": {
+    "en": "One-stop visual management of DSH Skills and MCP servers: on-demand MCP loading, in-session hot reload, and SKILL/MCP descriptions viewable in the plugin.",
+    "zh": "一站式可视化管理 DSH 的 SKILL 与 MCP：MCP按需加载、会话内热重载、SKILL与MCP描述可在插件内直接查看。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
## Plugin

https://github.com/alone-tree/dsh-skill-mcp-manager

Host-level DSH plugin for one-stop visual management of Skills and MCP servers. Session start exposes on-demand MCP names plus short tool descriptions instead of full schemas; `mcp_load` reconnects and refreshes tools in the current session; Skills can be scanned from nested directories and temporarily hidden from the model.

## Author verification

Ran the plugin's local Node test suite from the plugin repository:

```text
node test/*.mjs
```

All of smoke, schema-check, skill-smoke, watcher-smoke, import-smoke, ui-smoke, frontmatter-smoke, and count-skills passed. Also used the plugin on a live DSH Desktop profile (`desktop`) to manage Skills and MCP servers through the settings UI.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically