### PR TITLE
Add NextE-Moffatt knowledge-base bundle

### DIFF
--- a/catalog/plugins/nexte-moffatt--deepseek-harness--packages--bundle--kb.json
+++ b/catalog/plugins/nexte-moffatt--deepseek-harness--packages--bundle--kb.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "NextE-Moffatt/deepseek-harness/packages/bundle/kb",
+  "name": "kb",
+  "repository": "https://github.com/NextE-Moffatt/deepseek-harness",
+  "category": "tools",
+  "description": {
+    "en": "An opt-in knowledge-base bundle with model-facing tools and a Web governance workbench.",
+    "zh": "一个可选知识库组合包，提供模型工具与 Web 治理工作台。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
## Summary

Adds the `NextE-Moffatt/deepseek-harness/packages/bundle/kb` plugin to the marketplace catalog.

## Source

- Repository: https://github.com/NextE-Moffatt/deepseek-harness
- Bundle: `packages/bundle/kb`
- Default branch: `kb-master`

## Local verification

- focused bundle test
- bundle TypeScript build
- repository lint
- pre-push typecheck