### PR TITLE
catalog: add xuanxuanerhao-droid/dsh-waimai-discount

### DIFF
--- a/catalog/plugins/xuanxuanerhao-droid--dsh-waimai-discount.json
+++ b/catalog/plugins/xuanxuanerhao-droid--dsh-waimai-discount.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "xuanxuanerhao-droid/dsh-waimai-discount",
+  "name": "dsh-waimai-discount",
+  "repository": "https://github.com/xuanxuanerhao-droid/dsh-waimai-discount",
+  "category": "skill",
+  "description": {
+    "en": "Takeout/delivery discount helper. Aggregates official coupon entry guides for Meituan, Ele.me, JD Delivery and Taobao Shanguo (14 channels), matching user input by platform and coupon type (red packet, new user, student, full-reduction, coupon pack). All entries are official, commission-free channel guides; no CPS affiliate links.",
+    "zh": "外卖优惠助手。聚合美团、饿了么、京东外卖、淘宝闪购等平台的官方领券渠道（14 个入口），按用户输入的平台与券类型（红包/新客/学生/满减/神券包）智能匹配并返回领取路径。全部为无返佣的官方入口指引，不含任何 CPS 推广链接。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
﻿## 摘要

将 [`xuanxuanerhao-droid/dsh-waimai-discount`](https://github.com/xuanxuanerhao-droid/dsh-waimai-discount) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`./cordis.patch.yml`
- 测试命令：`node tests/load.test.mjs`
- 测试结果：All 18 assertions passed（provider 注册、技能列出/获取、frontmatter 解析、内置查询引擎对学生/美团渠道的匹配全部通过）

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性、准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
