### PR TITLE
catalog: add ExElectron/dsh-tool-hongtou

### DIFF
--- a/catalog/plugins/exelectron--dsh-tool-hongtou.json
+++ b/catalog/plugins/exelectron--dsh-tool-hongtou.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ExElectron/dsh-tool-hongtou",
+  "name": "dsh-tool-hongtou",
+  "repository": "https://github.com/ExElectron/dsh-tool-hongtou",
+  "category": "tools",
+  "description": {
+    "en": "A DeepSeek Harness host-side plugin that turns a session's context into a standard red-header official document (Word 2003 XML) via a two-phase pipeline: an LLM-structured JSON outline, then deterministic template rendering.",
+    "zh": "DeepSeek Harness 主机侧插件：通过 /hongtou 命令将会话上下文生成为标准红头公文（Word 2003 XML）。两阶段解耦流水线——LLM 结构化 JSON 提纲（schema 校验与确定性回退）+ 确定性 Word 2003 XML 版式渲染，模板无文本框/批注。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
## Summary

Add `ExElectron/dsh-tool-hongtou` to the DeepSeek Harness plugin catalog.

## Plugin verification

- Repository: https://github.com/ExElectron/dsh-tool-hongtou
- Category: tools
- Bundle patch: `cordis.patch.yml`
- GitHub installation entry: committed to the default branch
- Repository topics: `dsh-plugin`
- License: MIT

## Author test evidence

```text
node --test --test-isolation=none test/schema.test.js test/phase1.test.js test/phase2.test.js test/e2e.test.js (node v24.18.0) — 24 tests, 24 passed (schema/phase1/phase2/e2e)
```

## Change scope

This PR adds exactly one catalog entry: `catalog/plugins/catalog/plugins/exelectron--dsh-tool-hongtou.json`.
