### PR TITLE
catalog: add dsh-wallpaper_share (YRN-playmaker/dsh-wallpaper_share)

### DIFF
--- a/catalog/plugins/yrn-playmaker--dsh-wallpaper-share.json
+++ b/catalog/plugins/yrn-playmaker--dsh-wallpaper-share.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "YRN-playmaker/dsh-wallpaper_share",
+  "name": "dsh-wallpaper_share",
+  "repository": "https://github.com/YRN-playmaker/dsh-wallpaper_share",
+  "category": "theme",
+  "description": {
+    "en": "Visualizes background work and mirrors the wallpapers currently shown on your Wallpaper Engine displays into the DSH web background, supporting videos, web pages, and select scene types.",
+    "zh": "后台工作可视化并同步壁纸引擎中显示器的壁纸，支持视频网页和部分场景类型。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
新增收录 `dsh-wallpaper_share`(YRN-playmaker/dsh-wallpaper_share),分类「主题与外观」(theme)。

该插件此前由 topic 扫描自动发现,页面介绍文字有误(与插件功能不符)。本条目提供准确的中文与英文介绍:

- **中文**:后台工作可视化并同步壁纸引擎中显示器的壁纸,支持视频网页和部分场景类型。
- **English**: Visualizes background work and mirrors the wallpapers currently shown on your Wallpaper Engine displays into the DSH web background, supporting videos, web pages, and select scene types.
- **安装**: `dsh plugin --profile web add github:YRN-playmaker/dsh-wallpaper_share`

仓库已具备 `dsh-plugin` topic;`package.json` 声明 `dsh.bundle.patch: "./cordis.patch.yml"` 且 patch 与入口 `lib/index.js` 均已提交(GitHub 安装方式为 VERIFIED)。