### PR TITLE
Add dsh-deepseek-status plugin

### DIFF
--- a/catalog/plugins/m0rt1s0114--dsh-deepseek-status.json
+++ b/catalog/plugins/m0rt1s0114--dsh-deepseek-status.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "M0rt1s0114/dsh-deepseek-status",
+  "name": "dsh-deepseek-status",
+  "repository": "https://github.com/M0rt1s0114/dsh-deepseek-status",
+  "category": "tools",
+  "description": {
+    "en": "Displays official DeepSeek API balance, a link to the DeepSeek platform usage page, and current peak/off-peak pricing status in the DSH session header.",
+    "zh": "鍦?DSH 浼氳瘽澶撮儴鏄剧ず瀹樻柟 DeepSeek API 浣欓銆丏eepSeek 骞冲彴鐢ㄩ噺椤甸摼鎺ワ紝浠ュ強褰撳墠宄拌胺瀹氫环鐘舵€併€?
+  },
+  "added": "2026-08-21"
+}

--- a/catalog/plugins/m0rt1s0114--dsh-deepseek-status.json
+++ b/catalog/plugins/m0rt1s0114--dsh-deepseek-status.json
@@ -6,7 +6,7 @@
   "category": "tools",
   "description": {
     "en": "Displays official DeepSeek API balance, a link to the DeepSeek platform usage page, and current peak/off-peak pricing status in the DSH session header.",
-    "zh": "鍦?DSH 浼氳瘽澶撮儴鏄剧ず瀹樻柟 DeepSeek API 浣欓銆丏eepSeek 骞冲彴鐢ㄩ噺椤甸摼鎺ワ紝浠ュ強褰撳墠宄拌胺瀹氫环鐘舵€併€?
+    "zh": "在 DSH 会话头部显示官方 DeepSeek API 余额、DeepSeek 平台用量页链接，以及当前峰谷定价状态。"
   },
   "added": "2026-08-21"
 }


### PR DESCRIPTION
Adds a new catalog entry for [dsh-deepseek-status](https://github.com/M0rt1s0114/dsh-deepseek-status).

The plugin shows official DeepSeek API balance, a link to the DeepSeek platform usage page, and current peak/off-peak pricing status in the DSH session header.

Only `catalog/plugins/m0rt1s0114--dsh-deepseek-status.json` is added.