### PR TITLE
Add plugin: dsh-ccswitch-sync

### DIFF
--- a/catalog/plugins/yu969774--dsh-ccswitch-sync.json
+++ b/catalog/plugins/yu969774--dsh-ccswitch-sync.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "yu969774/dsh-ccswitch-sync",
+  "name": "dsh-ccswitch-sync",
+  "repository": "https://github.com/yu969774/dsh-ccswitch-sync",
+  "category": "tools",
+  "description": {
+    "en": "Sync CC Switch (cc-switch) providers and models into DeepSeek Harness custom providers (llm-pi-ai).",
+    "zh": "把 CC Switch 中配置的模型/服务商同步为 DeepSeek Harness 自定义提供方（llm-pi-ai）。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
新增 dsh-ccswitch-sync 插件条目（catalog/plugins/yu969774--dsh-ccswitch-sync.json）。

把 CC Switch（cc-switch）中配置的模型/服务商同步为 DeepSeek Harness 自定义提供方（llm-pi-ai），自动写入 API 密钥，并支持网关 /models 模型发现与推理等级映射。