### PR TITLE
catalog: add Howe829/dsh-runtime/packages/dsh-runtime

### DIFF
--- a/catalog/plugins/howe829--dsh-runtime--packages--dsh-runtime.json
+++ b/catalog/plugins/howe829--dsh-runtime--packages--dsh-runtime.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Howe829/dsh-runtime/packages/dsh-runtime",
+  "name": "dsh-runtime",
+  "repository": "https://github.com/Howe829/dsh-runtime",
+  "category": "dev",
+  "description": {
+    "en": "A read-only Runtime Explorer for DeepSeek Harness that visualizes Cordis runtime state, plugin and service relationships, Effect activity, and session request metadata.",
+    "zh": "面向 DeepSeek Harness 的只读 Runtime Explorer，可视化 Cordis 运行时状态、插件与服务关系、Effect 活动及会话请求元数据。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
## 摘要

将 [`Howe829/dsh-runtime/packages/dsh-runtime`](https://github.com/Howe829/dsh-runtime) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`packages/dsh-runtime/package.json`
- 子目录：`packages/dsh-runtime`（安装为 `github:Howe829/dsh-runtime#path:packages/dsh-runtime`）
- Bundle patch：`packages/dsh-runtime/cordis.patch.yml`
- 测试命令：`npm run verify`；`npm run pack:dry-run`；将 `@howardchan/dsh-runtime@0.1.3` 安装到隔离的 DSH `0.1.0-rc.8` Web profile；在匹配的本地 rc.8 Harness 中执行浏览器验收
- 测试结果：仓库验证与 3 个独立 Bundle 测试通过；35 文件 npm tarball dry-run 通过；公开 npm 包安装和 profile 组合通过；侧边栏入口、运行时总览、Plugin Activity、关系图谱搜索/缩放及 Request Trace 空状态通过真实浏览器验收。当前公开 DSH rc.8 Web 构建本身存在 `@deepseek-ai/dsh-client-schema-form` module-table 缺失，发生在第三方插件加载前，因此浏览器功能验收使用匹配的本地 rc.8 Harness 构建。

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
