### PR TITLE
catalog: add dsh-ezprot-plugin

### DIFF
--- a/catalog/plugins/yukunr--dsh-ezprot-plugin.json
+++ b/catalog/plugins/yukunr--dsh-ezprot-plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "YukunR/dsh-ezprot-plugin",
+  "name": "dsh-ezprot-plugin",
+  "repository": "https://github.com/YukunR/dsh-ezprot-plugin",
+  "category": "tools",
+  "description": {
+    "en": "Plug-and-play proteomics analysis: auto-managed R 4.4 runtime and a traceable normalization / PCA / batch-correction / differential-expression / GO-KEGG enrichment / GSEA pipeline with cached annotation backgrounds.",
+    "zh": "即插即用的蛋白质组学分析插件：自动管理 R 4.4 运行时，提供归一化 / PCA / 批次校正 / 差异表达 / GO/KEGG 富集 / GSEA 的逐步可回溯流程，注释背景自动缓存。"
+  },
+  "added": "2026-08-17"
+}


### PR DESCRIPTION
Added a new plugin for proteomics analysis with detailed features and multilingual support.

## Plugin

- Repository: https://github.com/YukunR/dsh-ezprot-plugin
- npm package: `dsh-ezprot-plugin` (0.1.1)

User-visible capability: given a protein-expression matrix (TSV/CSV/Excel), the
plugin runs the full analysis conversationally — normalization → PCA → optional
batch correction → differential expression → GO/KEGG enrichment → GSEA — one
traceable step at a time, ending with an interpretation report. It silently
installs and manages its own R 4.4.0 runtime and package library (no admin
rights, Westlake mirrors, retries and offline snapshot), builds per-organism
GO/KEGG annotation backgrounds once and caches them, supports an optional
Docker backend.

## Author verification

Tested by the author on Windows with local R 4.4.0 / Bioc 3.20 and with the
Docker backend:

- `npx @deepseek-ai/dsh plugin --profile web add dsh-ezprot-plugin@0.1.1`
  → installed 0.1.1; bundle auto-registered in `dsh.profile.bundles`
- `node tests/e2e/mount-smoke.mjs`
  → bundle resolution + `apply()` + all 8 `proteomics_*` tools registered
- `node tests/e2e/drive.mjs`
  → full pipeline over the mouse fixture dataset (normalize → PCA → DEA →
  enrichment → GSEA), all steps green
- `node tests/e2e/checkpoint-smoke.R` → `CHECKPOINT_SMOKE_OK`
- R runtime deep probe (`proteomics_environment action=verify`)
  → `CHECK_RESULT: ALL OK`
- Docker backend:
  `docker run --rm yukunru/ezprot:latest Rscript /opt/ezprot/check_runtime.R /opt/ezprot/manifest-runtime.json`
  → `CHECK_RESULT: ALL OK`

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically

## Maintainer API compatibility

Catalog-only plugin submissions leave this section unchecked. Maintainer changes that touch
API routes, projections, parameters, defaults, status/error codes, headers, pagination,
ordering, authentication or shared API code complete it.

- [ ] This change has no API behavior impact, or its API impact is described above
- [ ] Every added or changed API route is registered in `apps/web/contracts/api-surface.json`
- [ ] Existing-version behavior remains backward compatible and historical contract fixtures were not casually rewritten
- [ ] Any breaking behavior uses a new versioned route while the previous version remains available
- [ ] `npm run test:api-contract` passes
