### PR TITLE
add: yoiizesdev-crypto/DSH-Balance-display — DeepSeek 余额徽章插件

### DIFF
--- a/catalog/plugins/yoiizesdev-crypto--dsh-balance-display.json
+++ b/catalog/plugins/yoiizesdev-crypto--dsh-balance-display.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "yoiizesdev-crypto/DSH-Balance-display",
+  "name": "DSH-Balance-display",
+  "repository": "https://github.com/yoiizesdev-crypto/DSH-Balance-display",
+  "category": "ui",
+  "description": {
+    "en": "Real-time DeepSeek account balance badge in the sidebar footer with odometer roll animation, multi-currency support, balance trend chart, per-key usage statistics with historical backfill, and GitHub version auto-check.",
+    "zh": "侧边栏底部实时显示 DeepSeek 账户余额徽章：数字滚轮动画、多币种支持、余额趋势图、按 Key 用量统计（含安装前历史回填），并支持 GitHub 版本自动检查。"
+  },
+  "added": "2026-08-22"
+}


### PR DESCRIPTION
## 提交插件

新增 `catalog/plugins/yoiizesdev-crypto--dsh-balance-display.json`（唯一改动文件）：

- **id**: `yoiizesdev-crypto/DSH-Balance-display`
- **仓库**: https://github.com/yoiizesdev-crypto/DSH-Balance-display
- **分类**: `ui`

## 插件功能

侧边栏底部实时显示 DeepSeek 账户余额徽章：

- 数字滚轮动画（升绿降红）+ 手动刷新
- 多币种支持（CNY/USD 全部币种，CNY 恒在首位）
- 设置页「余额监控」：余额明细、趋势图（悬停十字光标）
- 按 API Key 用量统计，含安装前历史回填（扫描本地会话日志）
- 峰谷定价悬停面板、GitHub 版本自动检查

## 合规性

- `package.json` 声明 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件已提交
- 已添加 `dsh-plugin` GitHub topic（自动发现亦可收录）
- 已通过本地 `validateCatalogEntry` 校验（schema + 分类 + 文件名规则）
- 描述与代码一致，无夸大