### PR TITLE
Refresh dsh-win32 and dsh-movein descriptions

### DIFF
--- a/catalog/plugins/sjh9714--dsh-movein.json
+++ b/catalog/plugins/sjh9714--dsh-movein.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/sjh9714/dsh-movein",
   "category": "tools",
   "description": {
-    "en": "Moves an existing Claude Code or Codex CLI setup into DSH in one command, covering skills, slash commands, MCP servers, hooks, subagents and permission rules, with a dry run by default and a doctor command that checks the result afterwards.",
-    "zh": "一条命令把已有的 Claude Code 或 Codex CLI 配置迁入 DSH，涵盖技能、斜杠命令、MCP 服务器、hooks、子代理与权限规则，默认先执行 dry run，并提供 doctor 命令在迁移后检查结果。"
+    "en": "Previews and moves supported Claude Code, Codex, and OpenCode setup into DSH. Covers skills, commands, agents, instructions, and local or remote MCP servers, with OpenCode V1/V2 JSONC precedence, collision checks, backups, and doctor diagnostics.",
+    "zh": "预览并将 Claude Code、Codex 与 OpenCode 的受支持配置迁入 DSH。涵盖技能、命令、代理、指令与本地或远程 MCP 服务，支持 OpenCode V1/V2 JSONC 优先级、目标冲突检查、备份与 doctor 诊断。"
   },
   "added": "2026-08-18"
 }

--- a/catalog/plugins/sjh9714--dsh-win32.json
+++ b/catalog/plugins/sjh9714--dsh-win32.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/sjh9714/dsh-win32",
   "category": "tools",
   "description": {
-    "en": "Supplies the win32 process inspector that DSH's Minimal preset needs, so the persistent shell starts on Windows instead of failing with terminal inspection is unsupported on platform win32. Ships a busybox-w32 preset variant whose shell also runs under the workspace-write restricted token, where MSYS shells die at cygheap init.",
-    "zh": "补上 DSH 极简预设所需的 win32 进程检查器，使持久 shell 在 Windows 上可用，不再报 terminal inspection is unsupported on platform win32。另带 busybox-w32 预设变体，其 shell 在 workspace-write 受限令牌下同样可运行，而 MSYS 系 shell 在该令牌下死于 cygheap 初始化。"
+    "en": "Provides native Windows shell and Workspace Write sandbox presets for DSH without WSL. Sandboxed sessions use busybox-w32 and unrestricted sessions use Git Bash. Includes legacy text decoding and setup diagnostics.",
+    "zh": "为 DSH 提供无需 WSL 的原生 Windows shell 与 Workspace Write 沙箱预设。沙箱会话使用 busybox-w32，非受限会话使用 Git Bash，并提供旧编码读取与安装诊断。"
   },
   "added": "2026-08-18"
 }


### PR DESCRIPTION
Updates two existing catalog entries to match the current releases.

- dsh-win32 now describes the no WSL native shell and Workspace Write sandbox presets
- dsh-movein now describes Claude Code, Codex, OpenCode V1 and V2 migration

Validation

- npm ci passed with 0 vulnerabilities
- all 35 plugin review tests passed
- git diff --check passed