### PR TITLE
Add dsh-model-router catalog entry

### DIFF
--- a/catalog/plugins/thedeveloper256--dsh-model-router.json
+++ b/catalog/plugins/thedeveloper256--dsh-model-router.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "thedeveloper256/dsh-model-router",
+  "name": "dsh-model-router",
+  "repository": "https://github.com/thedeveloper256/dsh-model-router",
+  "category": "model",
+  "description": {
+    "en": "Role-based model routing for DeepSeek Harness: the planner (root agent) runs on deepseek-v4-pro, delegated executor subagents run on deepseek-v4-flash; ships a prompt section and a pro-flash-routing skill.",
+    "zh": "DeepSeek Harness 角色化模型路由：规划者（根 Agent）运行 deepseek-v4-pro，委派执行子 Agent 运行 deepseek-v4-flash；附带提示词区块与 pro-flash-routing 技能。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
Adds a curated catalog entry for dsh-model-router.

**Relationship to DSH:** dsh-model-router is a DeepSeek Harness plugin that enforces role-based model routing — planner (root agent) on deepseek-v4-pro, delegated executor subagents on deepseek-v4-flash — plus a prompt section and a pro-flash-routing skill. Installed via: dsh plugin --profile web add git+https://github.com/thedeveloper256/dsh-model-router

Single new file only, matching plugin.schema.json.