### PR TITLE
catalog: add dsh-peekfile-everything

### DIFF
--- a/catalog/plugins/fastengiel-kurai--dsh-peekfile-everything.json
+++ b/catalog/plugins/fastengiel-kurai--dsh-peekfile-everything.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "fastengiel-kurai/dsh-peekfile-everything",
+  "name": "dsh-peekfile-everything",
+  "repository": "https://github.com/fastengiel-kurai/dsh-peekfile-everything",
+  "category": "ui",
+  "description": {
+    "en": "A DSH plugin that searches workspace, WSL, and Windows Everything sources and provides local multi-format preview and conversation references.",
+    "zh": "DSH 全盘文件搜索与预览插件，统一搜索工作目录、WSL 和 Windows Everything 索引，并提供本地多格式预览与会话引用。"
+  },
+  "added": "2026-08-22"
+}


### PR DESCRIPTION
## Plugin

https://github.com/fastengiel-kurai/dsh-peekfile-everything

PeekFile searches workspace, WSL, and Windows Everything sources and provides local multi-format preview, clickable path handling, and conversation references. It can optionally integrate with Better Sidebar for workspace-contained files.

## Author verification

Verified on Windows 11 + WSL2 Ubuntu 24.04 with DSH `0.1.0-rc.8` at mainline commit `141eb6fef83422698aef7a981029e843e8161534`, Node.js >= 22, and optional Better Sidebar 0.14.0.

- `node --test tests/*.test.js`: 17/17 passed
- `node build.mjs`: passed
- `node --check src/client.js`: passed
- `node --check src/host.js`: passed
- `npm pack --dry-run`: Host/Client entry points, bundle patch, README, and LICENSE verified
- DSH Web smoke test: PeekFiles entry, search, file preview, and settings page loaded

Evidence: https://github.com/fastengiel-kurai/dsh-peekfile-everything/blob/main/VERIFICATION.md

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: not applicable; this is a new plugin
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically

## Maintainer API compatibility

Catalog-only submission; no API, workflow, application, or generated README files are changed.