### PR TITLE
Add robbyisrobby/dsh-codex-pins

### DIFF
--- a/catalog/plugins/robbyisrobby--dsh-codex-pins.json
+++ b/catalog/plugins/robbyisrobby--dsh-codex-pins.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "robbyisrobby/dsh-codex-pins",
+  "name": "dsh-codex-pins",
+  "repository": "https://github.com/robbyisrobby/dsh-codex-pins",
+  "category": "session",
+  "description": {
+    "en": "Split the DeepSeek Harness sidebar into a Pinned pane and a Recents pane with independent scrolling, and hide pinned sessions from Recents.",
+    "zh": "把 DeepSeek Harness 侧边栏分成置顶和最近两栏，各自独立滚动，置顶过的会话不再出现在最近列表里。"
+  },
+  "added": "2026-08-22"
+}


### PR DESCRIPTION
Adds one catalog entry: `catalog/plugins/robbyisrobby--dsh-codex-pins.json`.

- id: `robbyisrobby/dsh-codex-pins`
- category: `session`
- repository: https://github.com/robbyisrobby/dsh-codex-pins
- `dsh.bundle` is declared; install spec is `github:robbyisrobby/dsh-codex-pins`

Split the DeepSeek Harness sidebar into a Pinned pane and a Recents pane with independent scrolling, and hide pinned sessions from Recents.