### PR TITLE
Add blackdm666/dsh-plugin-88api-image

### DIFF
--- a/catalog/plugins/blackdm666--dsh-plugin-88api-image.json
+++ b/catalog/plugins/blackdm666--dsh-plugin-88api-image.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "blackdm666/dsh-plugin-88api-image",
+  "name": "dsh-plugin-88api-image",
+  "repository": "https://github.com/blackdm666/dsh-plugin-88api-image",
+  "category": "tools",
+  "description": {
+    "en": "Unified 88api.ai image generation and editing tools for DSH, supporting Image2 and Nano Banana models, persistent default-model selection, and masked API Key configuration.",
+    "zh": "面向 DSH 的统一 88api.ai 生图与编辑工具，支持 Image2 与 Nano Banana 模型、持久化默认模型选择和脱敏 API Key 配置。"
+  },
+  "added": "2026-08-22"
+}


### PR DESCRIPTION
## Plugin

https://github.com/blackdm666/dsh-plugin-88api-image

Unified 88api.ai image generation and editing tools for DSH, supporting Image2 and Nano Banana models, persistent default-model selection, and masked API Key configuration.

## Author verification

- `npm run check` — 16 tests passed; syntax and package dry-run passed.
- GitHub CI passed on Windows and Linux with Node.js 22.19 and 24: https://github.com/blackdm666/dsh-plugin-88api-image/actions/runs/32557317822
- The DSH smoke job packed the plugin, installed it into a clean DSH profile, and verified the `88api-image` bundle row.
- Local catalog review: `PASS blackdm666/dsh-plugin-88api-image: package.json -> cordis.patch.yml [git-install: entry_committed]`; `VERDICT auto-merge`.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically

## Maintainer API compatibility

Catalog-only submission; no API or application code is changed.