### PR TITLE
catalog: add kiligzzz/dsh-capability-manager

### DIFF
--- a/catalog/plugins/kiligzzz--dsh-capability-manager.json
+++ b/catalog/plugins/kiligzzz--dsh-capability-manager.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "kiligzzz/dsh-capability-manager",
+  "name": "dsh-capability-manager",
+  "repository": "https://github.com/kiligzzz/dsh-capability-manager",
+  "category": "dev",
+  "description": {
+    "en": "Capability Manager for DeepSeek Harness Desktop: manage MCP servers (~/.dsh/mcp.json, live mount/unmount) and Skills (~/.dsh/skills, toggle/delete/import/folder-sync) from a Settings-page UI. Dual-face dsh plugin (host + browser half), no DSH source changes.",
+    "zh": "DeepSeek Harness Desktop 能力管理器：在设置页内统一管理 MCP server（~/.dsh/mcp.json，实时挂载/卸载）与 Skill（~/.dsh/skills，开关/删除/导入/文件夹同步）。官方双面插件（host + 浏览器端），不改 DSH 源码。"
+  },
+  "added": "2026-08-21"
+}


### PR DESCRIPTION
Add catalog entry for [kiligzzz/dsh-capability-manager](https://github.com/kiligzzz/dsh-capability-manager) — a dual-face dsh plugin managing MCP servers and Skills from the Settings page.

- id: kiligzzz/dsh-capability-manager
- category: dev
- bilingual en/zh description included
- repo default branch `master` has package.json with `dsh.bundle.patch` -> `./cordis.patch.yml`

Validated locally with `validateCatalogEntry`.