### PR TITLE
catalog: add elviass/dsh-usage-insights

### DIFF
--- a/catalog/plugins/elviass--dsh-usage-insights.json
+++ b/catalog/plugins/elviass--dsh-usage-insights.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "elviass/dsh-usage-insights",
+  "name": "dsh-usage-insights",
+  "repository": "https://github.com/elviass/dsh-usage-insights",
+  "category": "model",
+  "description": {
+    "en": "Adds local usage and cost analytics for DeepSeek Harness, including tokens, cache activity, API balances, model pricing, and date-range breakdowns.",
+    "zh": "为 DeepSeek Harness 添加本地用量与费用分析，包括 Token、缓存活动、API 余额、模型价格和日期范围统计。"
+  },
+  "added": "2026-08-22"
+}


### PR DESCRIPTION
## 摘要

将 [`elviass/dsh-usage-insights`](https://github.com/elviass/dsh-usage-insights) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`pnpm check`；`pnpm test:coverage`；`pnpm audit --audit-level=high`；`pnpm pack --dry-run`；在独立临时 `DSH_HOME` 中执行 `dsh plugin --profile web add ./dsh-usage-insights-1.0.0.tgz`
- 测试结果：CI 在 Node.js 22.19.0 与 24 上通过检查、覆盖率测试、审计与打包检查；v1.0.0 已在 DSH `0.1.0-rc.7` 和 `0.1.1-rc.2` 的隔离环境中完成安装验证。

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书