### PR TITLE
catalog: rename elviass/dsh-usage-insights to elviass/dsh-cost-insights

### DIFF
--- a/catalog/plugins/elviass--dsh-cost-insights.json
+++ b/catalog/plugins/elviass--dsh-cost-insights.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../schema/plugin.schema.json",
-  "id": "elviass/dsh-usage-insights",
-  "name": "dsh-usage-insights",
-  "repository": "https://github.com/elviass/dsh-usage-insights",
+  "id": "elviass/dsh-cost-insights",
+  "name": "dsh-cost-insights",
+  "repository": "https://github.com/elviass/dsh-cost-insights",
   "category": "model",
   "description": {
     "en": "Adds local usage and cost analytics for DeepSeek Harness, including tokens, cache activity, API balances, model pricing, and date-range breakdowns.",


### PR DESCRIPTION
## 摘要

将目录条目从 [`elviass/dsh-usage-insights`](https://github.com/elviass/dsh-cost-insights) 重命名为 [`elviass/dsh-cost-insights`](https://github.com/elviass/dsh-cost-insights)，避免与现有插件使用相同显示名称。

GitHub 仓库已经完成重命名；原 URL 由 GitHub 自动重定向到新仓库。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`pnpm check`；`pnpm test:coverage`；`pnpm audit --audit-level=high`；`pnpm pack --dry-run`；`pnpm run release:build`；`pnpm run release:verify`
- 测试结果：元数据与语法检查通过；21/21 测试通过；无已知依赖漏洞；发布包包含 13 个预期文件并通过验证。GitHub PR 的 Node.js 22.19、Node.js 24 与 CodeQL 检查均通过。

## 目录提交确认

- [x] 本 PR 只重命名并更新一个 `catalog/plugins/*.json` 条目，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库保留 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解这是既有条目修改，静态审查通过后仍需维护者人工审核并手动合并；合并后由 CI 自动同步网站目录与 README