### PR TITLE
catalog: add Invoice Downloader DSH plugin

### DIFF
--- a/catalog/plugins/ethanyoq--invoice-downloader--plugins--dsh-invoice-downloader.json
+++ b/catalog/plugins/ethanyoq--invoice-downloader--plugins--dsh-invoice-downloader.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "EthanYoQ/Invoice-Downloader/plugins/dsh-invoice-downloader",
+  "name": "dsh-invoice-downloader",
+  "repository": "https://github.com/EthanYoQ/Invoice-Downloader",
+  "category": "tools",
+  "description": {
+    "en": "Local IMAP invoice download, OCR, archive, and Excel reimbursement summaries for DeepSeek Harness.",
+    "zh": "面向 DeepSeek Harness 的本地 IMAP 发票下载、OCR 识别、归档与 Excel 报销汇总。"
+  },
+  "added": "2026-08-22"
+}


### PR DESCRIPTION
Adds one catalog entry only, as required by the submission gate. The published bundle was installed from npm and verified with DeepSeek Harness Web on macOS.