### PR TITLE
Update 88API Image Studio branding

### DIFF
--- a/catalog/plugins/blackdm666--dsh-plugin-88api-image.json
+++ b/catalog/plugins/blackdm666--dsh-plugin-88api-image.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../schema/plugin.schema.json",
   "id": "blackdm666/dsh-plugin-88api-image",
-  "name": "dsh-plugin-88api-image",
+  "name": "88API Image Studio",
   "repository": "https://github.com/blackdm666/dsh-plugin-88api-image",
   "category": "tools",
   "description": {
-    "en": "Unified 88api.ai image generation and editing tools for DSH, supporting Image2 and Nano Banana models, persistent default-model selection, and masked API Key configuration.",
-    "zh": "面向 DSH 的统一 88api.ai 生图与编辑工具，支持 Image2 与 Nano Banana 模型、持久化默认模型选择和脱敏 API Key 配置。"
+    "en": "A conversational image studio for DSH with four Image2 and Nano Banana models, text-to-image, multi-reference editing, 2K/4K output, sequential batches, persistent defaults, and masked Key setup.",
+    "zh": "DSH 对话式生图工作台：统一接入 Image2 与 Nano Banana 四款模型，覆盖文生图、多参考图编辑、2K/4K 输出、顺序批量任务、默认模型持久化和脱敏 Key 配置。"
   },
   "added": "2026-08-22"
 }

--- a/catalog/plugins/blackdm666--dsh-plugin-88api-image.json
+++ b/catalog/plugins/blackdm666--dsh-plugin-88api-image.json
@@ -6,7 +6,7 @@
   "category": "tools",
   "description": {
     "en": "A conversational image studio for DSH with four Image2 and Nano Banana models, text-to-image, multi-reference editing, 2K/4K output, sequential batches, persistent defaults, and masked Key setup.",
-    "zh": "DSH 对话式生图工作台：统一接入 Image2 与 Nano Banana 四款模型，覆盖文生图、多参考图编辑、2K/4K 输出、顺序批量任务、默认模型持久化和脱敏 Key 配置。"
+    "zh": "统一接入 Image2 与 Nano Banana 四款模型，覆盖文生图、多参考图编辑、2K/4K 输出、顺序批量任务、默认模型持久化和脱敏 Key 配置。"
   },
   "added": "2026-08-22"
 }


### PR DESCRIPTION
## Plugin

https://github.com/blackdm666/dsh-plugin-88api-image

Correct the product-facing display name to **88API Image Studio** and replace the initial generic copy with a factual capability summary covering the unified four-model workflow, text-to-image, multi-reference editing, 2K/4K output, sequential batches, and persistent defaults.

The repository/package identifier remains `dsh-plugin-88api-image` for DSH installation and discovery compatibility.

## Author verification

- Plugin repository v0.1.2: `npm run check` — 16 tests passed; syntax and package dry-run passed.
- GitHub CI covers Windows/Linux with Node.js 22.19 and 24, plus a clean DSH profile install smoke test.
- Local catalog review: `PASS blackdm666/dsh-plugin-88api-image: package.json -> cordis.patch.yml [git-install: entry_committed]`; `VERDICT manual-review`.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [ ] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [x] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically

## Maintainer API compatibility

Catalog-only metadata update; no API or application code is changed.