### PR TITLE
catalog:add-dsh-plugin-no-workspace

### DIFF
--- a/catalog/plugins/spookysandwich--dsh-plugin-no-workspace.json
+++ b/catalog/plugins/spookysandwich--dsh-plugin-no-workspace.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "SpookySandwich/dsh-plugin-no-workspace",
+  "name": "dsh-plugin-no-workspace",
+  "repository": "https://github.com/SpookySandwich/dsh-plugin-no-workspace",
+  "category": "session",
+  "description": {
+    "en": "Adds standalone conversations that can be created and displayed without a workspace while retaining the native workspace UI.",
+    "zh": "添加可脱离工作区创建和显示的独立会话，同时保留原生工作区界面。"
+  },
+  "added": "2026-08-23"
+}


### PR DESCRIPTION
## Plugin submission

Adds `SpookySandwich/dsh-plugin-no-workspace` as one new session-category catalog entry.

- Repository has the `dsh-plugin` topic.
- Root `package.json` declares `dsh.bundle.patch`.
- `cordis.patch.yml` and committed entry points are present.
- Local static review result: `PASS ... [git-install: entry_committed]`, `VERDICT auto-merge`.
- Plugin v1.0.0 was verified against DSH 0.1.1-rc.2 with 88 automated tests and real desktop E2E coverage.
