### PR TITLE
fix(dsh1024): keep the store online when the catalog has invalid entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-1024store-monorepo",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-1024store-monorepo",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "workspaces": [
         "apps/web",
@@ -3805,7 +3805,7 @@
       "license": "MIT"
     },
     "packages/dsh1024": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "bin": {
         "dsh1024": "bin/dsh1024.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-1024store-monorepo",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "license": "MIT",
   "homepage": "https://deepseek1024.com/",

--- a/packages/dsh1024/lib/registry.js
+++ b/packages/dsh1024/lib/registry.js
@@ -67,14 +67,27 @@ export function validateRegistry(value) {
         throw new Error('registry categories are invalid');
     }
     const categoryIds = new Set(registry.categories.map(category => category.id));
-    if (!Array.isArray(registry.plugins) || registry.plugins.length === 0) {
+    const rawPlugins = registry.plugins;
+    if (!Array.isArray(rawPlugins) || rawPlugins.length === 0) {
         throw new Error('registry plugins are empty');
     }
-    if (registry.count !== registry.plugins.length)
+    if (registry.count !== rawPlugins.length)
         throw new Error('registry count does not match plugins');
-    if (!registry.plugins.every(plugin => isPlugin(plugin, categoryIds))) {
-        throw new Error('registry contains an invalid plugin');
-    }
+    // One malformed catalog entry must not take the whole store down: skip
+    // entries that fail strict validation instead of rejecting the entire
+    // registry, which previously surfaced as HTTP 503 on /dsh1024/installed and
+    // made every installed plugin unrecognizable (issue #159). Valid entries are
+    // unaffected and invalid ones are never installable.
+    const validPlugins = rawPlugins.filter(plugin => isPlugin(plugin, categoryIds));
+    // `count` is the server's raw plugin count and no longer matches the filtered
+    // array above. The persisted cache stores this exact registry object, so
+    // re-hydrating it later re-ran the strict count check against the
+    // already-filtered array, threw, and forced a network round-trip on every
+    // request — the whole store went 503 whenever the API was slow or
+    // unreachable. Normalize count to the filtered length so the cached registry
+    // round-trips through the same validation.
+    registry.plugins = validPlugins;
+    registry.count = validPlugins.length;
     return registry;
 }
 /**
@@ -183,10 +196,35 @@ function hydrateRegistryCache(path, registryUrl) {
                 || persisted.fetchedAt > Date.now() + CACHE_TTL_MS
                 || Date.now() - persisted.fetchedAt > PERSISTED_CACHE_MAX_AGE_MS)
                 return;
+            let registry = null;
+            try {
+                registry = validateRegistry(persisted.registry);
+            }
+            catch {
+                // Self-heal a cache written before the count normalization fix: its
+                // `count` reflects the raw upstream total while `plugins` was already
+                // filtered, so strict validation rejects it. The payload is the
+                // plugin's own last-good output — re-validate it with the count
+                // reconciled to the filtered length.
+                const cached = persisted.registry;
+                if (cached !== null && typeof cached === 'object' && !Array.isArray(cached)) {
+                    try {
+                        registry = validateRegistry({
+                            ...cached,
+                            count: Array.isArray(cached.plugins) ? cached.plugins.length : 0,
+                        });
+                    }
+                    catch {
+                        registry = null;
+                    }
+                }
+            }
+            if (registry === null)
+                return;
             cache = {
                 url: registryUrl,
                 at: persisted.fetchedAt,
-                registry: validateRegistry(persisted.registry),
+                registry,
                 persisted: true,
             };
         }

--- a/packages/dsh1024/lib/routes.js
+++ b/packages/dsh1024/lib/routes.js
@@ -348,33 +348,51 @@ export function mountMarketRoutes(webServer, config) {
             handler: async (request, response) => {
                 if (!requireMethod(request, response, 'GET'))
                     return;
+                const installed = readInstalled(config.profile);
+                let registry = null;
+                let registryError = null;
                 try {
-                    const installed = readInstalled(config.profile);
-                    const { registry } = await loadRegistry(config.registryUrl, fetch, { dshHome });
-                    const pluginIds = installedPluginIds(installed, registry.plugins);
-                    const idSet = new Set(pluginIds);
-                    const categoryLabels = new Map(registry.categories.map(category => [category.id, category.label]));
+                    ;
+                    ({ registry } = await loadRegistry(config.registryUrl, fetch, { dshHome }));
+                }
+                catch (error) {
+                    registryError = error instanceof Error ? error.message : String(error);
+                }
+                if (registry === null) {
+                    // The registry is unreachable and no last-good cache exists. Report
+                    // the local install state with an empty catalog mapping instead of
+                    // failing the whole panel with 503, so the installed plugins stay
+                    // visible (issue #159).
                     sendJson(response, 200, {
                         profile: config.profile,
                         installed,
-                        pluginIds,
-                        plugins: registry.plugins.filter(plugin => idSet.has(plugin.id)).map(plugin => ({
-                            id: plugin.id,
-                            name: plugin.name,
-                            owner: plugin.owner,
-                            url: plugin.url,
-                            category: plugin.category,
-                            categoryLabel: categoryLabels.get(plugin.category) ?? {},
-                            description: plugin.description,
-                            install: plugin.install,
-                            added: plugin.added,
-                            stars: plugin.stars ?? null,
-                        })),
+                        pluginIds: [],
+                        plugins: [],
+                        registryError,
                     });
+                    return;
                 }
-                catch (error) {
-                    sendJson(response, 503, { error: error instanceof Error ? error.message : String(error) });
-                }
+                const pluginIds = installedPluginIds(installed, registry.plugins);
+                const idSet = new Set(pluginIds);
+                const categoryLabels = new Map(registry.categories.map(category => [category.id, category.label]));
+                sendJson(response, 200, {
+                    profile: config.profile,
+                    installed,
+                    pluginIds,
+                    plugins: registry.plugins.filter(plugin => idSet.has(plugin.id)).map(plugin => ({
+                        id: plugin.id,
+                        name: plugin.name,
+                        owner: plugin.owner,
+                        url: plugin.url,
+                        category: plugin.category,
+                        categoryLabel: categoryLabels.get(plugin.category) ?? {},
+                        description: plugin.description,
+                        install: plugin.install,
+                        added: plugin.added,
+                        stars: plugin.stars ?? null,
+                    })),
+                    ...(registryError === null ? {} : { registryError }),
+                });
             },
         }),
         webServer.register({

--- a/packages/dsh1024/package.json
+++ b/packages/dsh1024/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh1024",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The 1024 Store for DeepSeek Harness: in-app plugin market and tracked installer CLI.",
   "license": "MIT",
   "homepage": "https://deepseek1024.com/",

--- a/packages/dsh1024/src/registry.ts
+++ b/packages/dsh1024/src/registry.ts
@@ -108,13 +108,26 @@ export function validateRegistry(value: unknown): Registry {
     throw new Error('registry categories are invalid')
   }
   const categoryIds = new Set(registry.categories.map(category => category.id))
-  if (!Array.isArray(registry.plugins) || registry.plugins.length === 0) {
+  const rawPlugins = registry.plugins
+  if (!Array.isArray(rawPlugins) || rawPlugins.length === 0) {
     throw new Error('registry plugins are empty')
   }
-  if (registry.count !== registry.plugins.length) throw new Error('registry count does not match plugins')
-  if (!registry.plugins.every(plugin => isPlugin(plugin, categoryIds))) {
-    throw new Error('registry contains an invalid plugin')
-  }
+  if (registry.count !== rawPlugins.length) throw new Error('registry count does not match plugins')
+  // One malformed catalog entry must not take the whole store down: skip
+  // entries that fail strict validation instead of rejecting the entire
+  // registry, which previously surfaced as HTTP 503 on /dsh1024/installed and
+  // made every installed plugin unrecognizable (issue #159). Valid entries are
+  // unaffected and invalid ones are never installable.
+  const validPlugins = rawPlugins.filter(plugin => isPlugin(plugin, categoryIds))
+  // `count` is the server's raw plugin count and no longer matches the filtered
+  // array above. The persisted cache stores this exact registry object, so
+  // re-hydrating it later re-ran the strict count check against the
+  // already-filtered array, threw, and forced a network round-trip on every
+  // request — the whole store went 503 whenever the API was slow or
+  // unreachable. Normalize count to the filtered length so the cached registry
+  // round-trips through the same validation.
+  registry.plugins = validPlugins
+  registry.count = validPlugins.length
   return registry as unknown as Registry
 }
 
@@ -237,10 +250,32 @@ function hydrateRegistryCache(path: string, registryUrl: string): Promise<void> 
         || typeof persisted.fetchedAt !== 'number' || !Number.isFinite(persisted.fetchedAt)
         || persisted.fetchedAt > Date.now() + CACHE_TTL_MS
         || Date.now() - persisted.fetchedAt > PERSISTED_CACHE_MAX_AGE_MS) return
+      let registry: Registry | null = null
+      try {
+        registry = validateRegistry(persisted.registry)
+      } catch {
+        // Self-heal a cache written before the count normalization fix: its
+        // `count` reflects the raw upstream total while `plugins` was already
+        // filtered, so strict validation rejects it. The payload is the
+        // plugin's own last-good output — re-validate it with the count
+        // reconciled to the filtered length.
+        const cached = persisted.registry as Record<string, unknown> | null | undefined
+        if (cached !== null && typeof cached === 'object' && !Array.isArray(cached)) {
+          try {
+            registry = validateRegistry({
+              ...cached,
+              count: Array.isArray(cached.plugins) ? cached.plugins.length : 0,
+            })
+          } catch {
+            registry = null
+          }
+        }
+      }
+      if (registry === null) return
       cache = {
         url: registryUrl,
         at: persisted.fetchedAt,
-        registry: validateRegistry(persisted.registry),
+        registry,
         persisted: true,
       }
     } catch {

--- a/packages/dsh1024/src/routes.ts
+++ b/packages/dsh1024/src/routes.ts
@@ -6,7 +6,7 @@ import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { installExtraArgs, installTarget, loadRegistry, parseGitHubSource } from './registry.ts'
-import type { RegistryPlugin } from './registry.ts'
+import type { Registry, RegistryPlugin } from './registry.ts'
 import { runPluginCommand } from './shared/install-runner.ts'
 import type { InstallInvocation } from './shared/install-runner.ts'
 import { reportInstallEvent } from './telemetry.ts'
@@ -402,32 +402,49 @@ export function mountMarketRoutes(webServer: WebServerService, config: MarketRou
       path: '/dsh1024/installed',
       handler: async (request, response) => {
         if (!requireMethod(request, response, 'GET')) return
+        const installed = readInstalled(config.profile)
+        let registry: Registry | null = null
+        let registryError: string | null = null
         try {
-          const installed = readInstalled(config.profile)
-          const { registry } = await loadRegistry(config.registryUrl, fetch, { dshHome })
-          const pluginIds = installedPluginIds(installed, registry.plugins)
-          const idSet = new Set(pluginIds)
-          const categoryLabels = new Map(registry.categories.map(category => [category.id, category.label]))
+          ;({ registry } = await loadRegistry(config.registryUrl, fetch, { dshHome }))
+        } catch (error) {
+          registryError = error instanceof Error ? error.message : String(error)
+        }
+        if (registry === null) {
+          // The registry is unreachable and no last-good cache exists. Report
+          // the local install state with an empty catalog mapping instead of
+          // failing the whole panel with 503, so the installed plugins stay
+          // visible (issue #159).
           sendJson(response, 200, {
             profile: config.profile,
             installed,
-            pluginIds,
-            plugins: registry.plugins.filter(plugin => idSet.has(plugin.id)).map(plugin => ({
-              id: plugin.id,
-              name: plugin.name,
-              owner: plugin.owner,
-              url: plugin.url,
-              category: plugin.category,
-              categoryLabel: categoryLabels.get(plugin.category) ?? {},
-              description: plugin.description,
-              install: plugin.install,
-              added: plugin.added,
-              stars: plugin.stars ?? null,
-            })),
+            pluginIds: [],
+            plugins: [],
+            registryError,
           })
-        } catch (error) {
-          sendJson(response, 503, { error: error instanceof Error ? error.message : String(error) })
+          return
         }
+        const pluginIds = installedPluginIds(installed, registry.plugins)
+        const idSet = new Set(pluginIds)
+        const categoryLabels = new Map(registry.categories.map(category => [category.id, category.label]))
+        sendJson(response, 200, {
+          profile: config.profile,
+          installed,
+          pluginIds,
+          plugins: registry.plugins.filter(plugin => idSet.has(plugin.id)).map(plugin => ({
+            id: plugin.id,
+            name: plugin.name,
+            owner: plugin.owner,
+            url: plugin.url,
+            category: plugin.category,
+            categoryLabel: categoryLabels.get(plugin.category) ?? {},
+            description: plugin.description,
+            install: plugin.install,
+            added: plugin.added,
+            stars: plugin.stars ?? null,
+          })),
+          ...(registryError === null ? {} : { registryError }),
+        })
       },
     }),
     webServer.register({

--- a/packages/dsh1024/tests/registry.test.mjs
+++ b/packages/dsh1024/tests/registry.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -193,40 +193,101 @@ test('a monorepo subpackage installs its own directory, not the repository root'
 })
 
 test('invalid API data cannot extend the installation allowlist', () => {
-  assert.throws(
-    () => validateRegistry({
-      ...registry,
-      plugins: [{ ...registry.plugins[0], target: 'github:attacker/other' }],
-    }),
-    /invalid plugin/,
-  )
-  assert.throws(
-    () => validateRegistry({
-      ...registry,
-      plugins: [{ ...registry.plugins[0], allowBuild: 'plugin;unsafe' }],
-    }),
-    /invalid plugin/,
-  )
-  assert.throws(
-    () => validateRegistry({
-      ...registry,
-      plugins: [{ ...registry.plugins[0], url: 'https://example.com/owner/repo' }],
-    }),
-    /invalid plugin/,
-  )
-  assert.throws(
-    () => validateRegistry({
-      ...registry,
-      plugins: [{ ...registry.plugins[0], category: 'unlisted' }],
-    }),
-    /invalid plugin/,
-  )
+  // Malformed entries are skipped rather than poisoning the whole registry:
+  // they must never become installable, but they also must not take the store
+  // down with a wholesale rejection (issue #159).
+  const invalid = { ...registry.plugins[0], target: 'github:attacker/other' }
+  const validated = validateRegistry({
+    ...registry,
+    count: 2,
+    plugins: [registry.plugins[0], invalid],
+  })
+  assert.deepEqual(validated.plugins, [registry.plugins[0]])
+  assert.equal(validated.count, 1)
+  // An unsafe build allowance is likewise filtered, never installable.
+  const unsafeAllowance = validateRegistry({
+    ...registry,
+    plugins: [{ ...registry.plugins[0], allowBuild: 'plugin;unsafe' }],
+  })
+  assert.equal(unsafeAllowance.count, 0)
+  assert.deepEqual(unsafeAllowance.plugins, [])
+  // Structural corruption is still fatal.
   assert.throws(() => validateRegistry({ ...registry, count: 2 }), /count does not match/)
   assert.throws(
     () => validateRegistry({ ...registry, categories: { tools: { en: 'Tools' } } }),
     /categories are invalid/,
   )
   assert.throws(() => validateRegistry({ ...registry, plugins: [] }), /plugins are empty/)
+})
+
+test('a single invalid entry is filtered and the count is normalized to match', () => {
+  const valid = registry.plugins[0]
+  const invalid = { ...registry.plugins[0], id: 'owner/bad', target: 'github:attacker/other' }
+  const validated = validateRegistry({ ...registry, count: 2, plugins: [valid, invalid] })
+  assert.equal(validated.count, 1)
+  assert.deepEqual(validated.plugins, [valid])
+  // An all-invalid response degrades to an empty allowlist instead of 503.
+  const empty = validateRegistry({ ...registry, count: 1, plugins: [invalid] })
+  assert.equal(empty.count, 0)
+  assert.deepEqual(empty.plugins, [])
+})
+
+test('the persisted cache round-trips after invalid entries are filtered', async () => {
+  clearRegistryCache()
+  const dshHome = await mkdtemp(join(tmpdir(), 'dsh1024-registry-filter-'))
+  const registryUrl = 'https://store.example/api/v1/registry'
+  const valid = registry.plugins[0]
+  const invalid = { ...registry.plugins[0], id: 'owner/bad', target: 'github:attacker/other' }
+  const payload = { ...registry, count: 2, plugins: [valid, invalid] }
+  const fetcher = async () => new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+  try {
+    const first = await loadRegistry(registryUrl, fetcher, { dshHome })
+    assert.equal(first.source, 'api')
+    assert.equal(first.registry.count, 1)
+    assert.deepEqual(first.registry.plugins, [valid])
+
+    // The persisted snapshot must re-hydrate cleanly: its count now matches the
+    // filtered plugins, so the next load never needs the network.
+    const cachePath = join(dshHome, '.dsh-1024store', 'registry-cache.json')
+    const persisted = JSON.parse(await readFile(cachePath, 'utf8'))
+    assert.equal(persisted.registry.count, persisted.registry.plugins.length)
+
+    clearRegistryCache()
+    const restored = await loadRegistry(registryUrl, async () => { throw new Error('offline') }, { dshHome })
+    assert.equal(restored.source, 'cache')
+    assert.equal(restored.registry.count, 1)
+    assert.deepEqual(restored.registry.plugins, [valid])
+  } finally {
+    clearRegistryCache()
+    await rm(dshHome, { recursive: true, force: true })
+  }
+})
+
+test('a stale poisoned cache self-heals without the network', async () => {
+  clearRegistryCache()
+  const dshHome = await mkdtemp(join(tmpdir(), 'dsh1024-registry-poison-'))
+  const registryUrl = 'https://store.example/api/v1/registry'
+  // Reproduce a cache written before the count normalization fix: the server's
+  // raw `count` while `plugins` was already filtered down.
+  const cacheDir = join(dshHome, '.dsh-1024store')
+  await mkdir(cacheDir, { recursive: true })
+  await writeFile(join(cacheDir, 'registry-cache.json'), JSON.stringify({
+    version: 1,
+    url: registryUrl,
+    fetchedAt: Date.now(),
+    registry: { ...registry, count: registry.plugins.length + 1 },
+  }))
+  try {
+    const restored = await loadRegistry(registryUrl, async () => { throw new Error('offline') }, { dshHome })
+    assert.equal(restored.source, 'cache')
+    assert.deepEqual(restored.registry, registry)
+  } finally {
+    clearRegistryCache()
+    await rm(dshHome, { recursive: true, force: true })
+  }
 })
 
 test('revalidation goes to the network even when the cache is still fresh', async () => {

--- a/packages/dsh1024/tests/routes.test.mjs
+++ b/packages/dsh1024/tests/routes.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -9,6 +9,7 @@ import {
   mountMarketRoutes,
   readProfilePnpmStoreDir,
 } from '../lib/routes.js'
+import { clearRegistryCache, loadRegistry } from '../lib/registry.js'
 
 const baseConfig = {
   profile: 'market-test',
@@ -16,14 +17,34 @@ const baseConfig = {
   updateUrl: 'https://deepseek1024.com/api/v1/self/update',
 }
 
-function routeHarness(embedUrl) {
+const catalog = {
+  name: 'dsh-1024store-catalog',
+  updated: '2026-08-15T00:00:00Z',
+  count: 2,
+  categories: [{ id: 'tools', order: 1, label: { en: 'Tools', zh: '工具' } }],
+  plugins: [
+    {
+      id: 'owner/mono/packages/child', name: 'child', owner: 'owner',
+      url: 'https://github.com/owner/mono', category: 'tools', description: { en: 'child' },
+      install: 'dsh plugin add github:owner/mono#path:packages/child',
+      target: 'github:owner/mono#path:packages/child', added: '2026-01-01',
+    },
+    {
+      id: 'owner/npm-plugin', name: 'npm-plugin', owner: 'owner',
+      url: 'https://github.com/owner/npm-plugin', category: 'tools', description: { en: 'npm' },
+      install: 'dsh plugin add published-plugin', target: 'published-plugin', added: '2026-01-01',
+    },
+  ],
+}
+
+function routeHarness(embedUrl, overrides = {}) {
   const routes = new Map()
   const dispose = mountMarketRoutes({
     register(route) {
       routes.set(route.path, route)
       return () => routes.delete(route.path)
     },
-  }, { ...baseConfig, embedUrl })
+  }, { ...baseConfig, embedUrl, ...overrides })
   return { routes, dispose }
 }
 
@@ -133,4 +154,89 @@ test('plugin installs reuse the pnpm store already linked to the profile', async
 
   await writeFile(join(modules, '.modules.yaml'), JSON.stringify({ storeDir: '../unsafe' }))
   assert.equal(readProfilePnpmStoreDir(profile), undefined)
+})
+
+test('/dsh1024/installed maps profile dependencies against the catalog', async () => {
+  const dshHome = await mkdtemp(join(tmpdir(), 'dsh1024-installed-route-'))
+  const profile = join(dshHome, 'profiles', 'market-test')
+  await mkdir(profile, { recursive: true })
+  await writeFile(join(profile, 'package.json'), JSON.stringify({
+    dependencies: {
+      child: 'github:owner/mono#path:packages/child&commit=abc123',
+      'published-plugin': '^1.2.3',
+    },
+  }))
+  const previous = process.env.DSH_HOME
+  process.env.DSH_HOME = dshHome
+  try {
+    // Seed the process cache through the shared loader so the route never
+    // touches the network.
+    clearRegistryCache()
+    await loadRegistry(baseConfig.registryUrl, async () => new Response(JSON.stringify(catalog), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    const { routes, dispose } = routeHarness('https://deepseek1024.com/embed/store?bridge=dsh1024-v1')
+    let status = 0
+    let body = null
+    await routes.get('/dsh1024/installed').handler(
+      { method: 'GET' },
+      {
+        writeHead(value) { status = value },
+        end(value = '') { body = JSON.parse(value) },
+      },
+    )
+    assert.equal(status, 200)
+    assert.equal(body.profile, 'market-test')
+    assert.deepEqual(body.pluginIds, ['owner/mono/packages/child', 'owner/npm-plugin'])
+    assert.equal(body.plugins.length, 2)
+    assert.equal(body.registryError, undefined)
+    dispose()
+  } finally {
+    clearRegistryCache()
+    delete process.env.DSH_HOME
+    if (previous !== undefined) process.env.DSH_HOME = previous
+    await rm(dshHome, { recursive: true, force: true })
+  }
+})
+
+test('/dsh1024/installed degrades to the local install state when the registry is unreachable', async () => {
+  const dshHome = await mkdtemp(join(tmpdir(), 'dsh1024-installed-route-offline-'))
+  const profile = join(dshHome, 'profiles', 'market-test')
+  await mkdir(profile, { recursive: true })
+  await writeFile(join(profile, 'package.json'), JSON.stringify({
+    dependencies: { 'published-plugin': '^1.2.3' },
+  }))
+  const previous = process.env.DSH_HOME
+  process.env.DSH_HOME = dshHome
+  try {
+    clearRegistryCache()
+    // `.invalid` is guaranteed not to resolve, so the registry fetch fails and
+    // no cache exists: the route must answer 200 with the local install state
+    // instead of failing the whole panel with 503.
+    const { routes, dispose } = routeHarness(
+      'https://deepseek1024.com/embed/store?bridge=dsh1024-v1',
+      { registryUrl: 'https://store.invalid/api/v1/registry' },
+    )
+    let status = 0
+    let body = null
+    await routes.get('/dsh1024/installed').handler(
+      { method: 'GET' },
+      {
+        writeHead(value) { status = value },
+        end(value = '') { body = JSON.parse(value) },
+      },
+    )
+    assert.equal(status, 200)
+    assert.deepEqual(body.pluginIds, [])
+    assert.deepEqual(body.plugins, [])
+    assert.equal(typeof body.registryError, 'string')
+    assert.equal(body.installed['published-plugin'], '^1.2.3')
+    dispose()
+  } finally {
+    clearRegistryCache()
+    delete process.env.DSH_HOME
+    if (previous !== undefined) process.env.DSH_HOME = previous
+    await rm(dshHome, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
Fixes #159

## Problem
A single malformed catalog entry (e.g. an uppercase \--allow-build\ scope) made the whole 1024 Store unusable:

- \/dsh1024/installed\ answered **503** and no installed plugin was recognizable (无法识别已安装插件).
- The strict \alidateRegistry\ rejected the entire registry when any entry failed validation.
- Even with invalid entries skipped, the persisted cache kept the server's raw \count\ (9229) while \plugins\ was already filtered (9228); re-hydrating that cache re-ran the strict count check and threw, forcing a network round-trip on **every** request — the store went 503 again whenever the API was slow or unreachable.

## Fix (dsh1024 0.4.2)
1. **\alidateRegistry\** — skip entries that fail strict validation instead of rejecting the whole registry; invalid entries are never installable.
2. **Count normalization** — after filtering, set \count\ to the filtered length so the persisted cache round-trips through the same validation (no more poisoned cache / forced network dependency).
3. **Cache self-heal** — \hydrateRegistryCache\ re-validates stale caches written before the normalization fix by reconciling the count, so existing installs recover without the network.
4. **\/dsh1024/installed\ graceful degradation** — when the registry is unreachable and no cache exists, answer **200** with the local install state plus \egistryError\ instead of 503, so the installed-plugin list stays visible.

## Verification
- \
pm test --workspace dsh1024\: 79 + 41 tests pass, preflight ok (adds 6 regression tests: filter + count normalization, cache round-trip, poisoned-cache self-heal, installed mapping, offline degradation).
- Live check against the real catalog: 9228/9229 entries validated, \/dsh1024/installed\ returns 200 and recognizes all 22 locally installed plugins.