### PR TITLE
catalog: add dsh-plugin-cloud (DSH Cloud gateway provider)

### DIFF
--- a/catalog/plugins/agentsdanceai--deepseek-harness-cloud--packages--dsh-plugin-cloud.json
+++ b/catalog/plugins/agentsdanceai--deepseek-harness-cloud--packages--dsh-plugin-cloud.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "AgentsDanceAI/deepseek-harness-cloud/packages/dsh-plugin-cloud",
+  "name": "dsh-plugin-cloud",
+  "repository": "https://github.com/AgentsDanceAI/deepseek-harness-cloud",
+  "category": "model",
+  "description": {
+    "en": "Connects DeepSeek Harness to a DSH Cloud gateway (hosted or self-hosted): device-authorized login plus a multi-model provider row written into the user config layer.",
+    "zh": "把 DeepSeek Harness 接入 DSH Cloud 网关（托管或自部署）：设备授权登录，并在用户配置层写入多模型提供方条目。"
+  },
+  "added": "2026-08-22"
+}


### PR DESCRIPTION
Adds one new entry per CONTRIBUTING: monorepo subpackage id `AgentsDanceAI/deepseek-harness-cloud/packages/dsh-plugin-cloud` (manifest at exactly that path, non-empty `dsh.bundle.patch` committed), `dsh-plugin` topic set, published on npm as `dsh-plugin-cloud` with `repository.url` + `repository.directory` pointing back here. No build step — plain ESM, installs cleanly from GitHub. Tested by the maintainer (author here).