### PR TITLE
Add dsh-pickdom

### DIFF
--- a/catalog/plugins/xiaobaiyg09--dsh-pickdom.json
+++ b/catalog/plugins/xiaobaiyg09--dsh-pickdom.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "xiaobaiyg09/dsh-pickdom",
+  "name": "dsh-pickdom",
+  "repository": "https://github.com/xiaobaiyg09/dsh-pickdom",
+  "category": "tools",
+  "description": {
+    "en": "Provides a DSH sidebar browser for local HTML and HTTP/HTTPS pages, with DOM element picking that inserts structured references into the Agent composer; local HTML also supports visual editing and saving.",
+    "zh": "为 DSH 提供本地 HTML 与 HTTP/HTTPS 页面的侧边栏浏览器，可框选 DOM 元素并将结构化引用插入 Agent 输入框；本地 HTML 还支持可视化编辑与保存。"
+  },
+  "added": "2026-08-23"
+}


### PR DESCRIPTION
## 插件简介

`dsh-pickdom` 为 DSH 提供本地 HTML 与 HTTP/HTTPS 页面的侧边栏浏览能力。它支持像 Cursor 一样框选 DOM 元素，并将结构化元素引用插入 Agent 输入框，方便直接描述和修改页面；本地 HTML 还支持可视化编辑与保存。

- Plugin repository: https://github.com/xiaobaiyg09/dsh-pickdom
- Category: `tools`
- Catalog entry: `catalog/plugins/xiaobaiyg09--dsh-pickdom.json`