### PR TITLE
Add openma-ai/Martty

### DIFF
--- a/catalog/plugins/openma-ai--martty.json
+++ b/catalog/plugins/openma-ai--martty.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "openma-ai/Martty",
+  "name": "Martty",
+  "repository": "https://github.com/openma-ai/Martty",
+  "category": "ui",
+  "description": {
+    "en": "DSH-first Rust/ratatui agent TUI with streamed tool calls, subagents, durable sessions, and a Cordis-extensible client UI.",
+    "zh": "面向 DeepSeek Harness 的 Rust/ratatui Agent TUI，支持流式工具调用、子代理、持久会话和可扩展的 Cordis 客户端界面。"
+  },
+  "added": "2026-08-23"
+}


### PR DESCRIPTION
Adds one catalog entry for the Martty DSH bundle and terminal client. The bundle manifest and patch file are in the repository's `npm/` package directory.

Validation: `npm run test:plugin-review`
