### PR TITLE
Add task-chime plugin (notify category)

### DIFF
--- a/catalog/plugins/abel-86--task-chime.json
+++ b/catalog/plugins/abel-86--task-chime.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Abel-86/task-chime",
+  "name": "task-chime",
+  "repository": "https://github.com/Abel-86/task-chime",
+  "category": "notify",
+  "description": {
+    "en": "Play local sounds for approval/permission requests and task completion, configurable from the Web GUI.",
+    "zh": "审批/权限请求与任务完成提示音，可在 GUI 设置中自定义声音、音量与冷却。"
+  },
+  "added": "2026-08-23"
+}


### PR DESCRIPTION
Adds a single catalog entry:

- \catalog/plugins/abel-86--task-chime.json\
- id: \Abel-86/task-chime\
- category: \
otify\
- npm: \	ask-chime\ (also installable via \github:Abel-86/task-chime\)
- package.json declares \dsh.bundle.patch\ and the patch file is committed.

DSH task chime: plays local sounds for approval/permission requests and task completion, configurable from the Web GUI settings.