### PR TITLE
Add SpookySandwich/dsh-plugin-message-edit (session)

### DIFF
--- a/catalog/plugins/spookysandwich--dsh-plugin-message-edit.json
+++ b/catalog/plugins/spookysandwich--dsh-plugin-message-edit.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "SpookySandwich/dsh-plugin-message-edit",
+  "name": "dsh-plugin-message-edit",
+  "repository": "https://github.com/SpookySandwich/dsh-plugin-message-edit",
+  "category": "session",
+  "description": {
+    "en": "Edit an already-sent message to rewind the conversation to that turn and branch from it, keeping the previous version. A counter under the bubble switches between versions, and a Versions tab draws the whole family as a turn-level tree. Control placement follows a ChatGPT, DeepSeek or Claude preset.",
+    "zh": "编辑已发送的消息，将对话回溯到该轮次并从此分叉，同时保留原有版本。气泡下方的计数器用于切换版本，「版本」标签页以轮次级树状图展示整个版本家族。控件位置提供 ChatGPT、DeepSeek、Claude 三种预设。"
+  },
+  "added": "2026-08-23"
+}


### PR DESCRIPTION
Adds one new catalog entry: `catalog/plugins/spookysandwich--dsh-plugin-message-edit.json`. No other paths touched.

- Repository: https://github.com/SpookySandwich/dsh-plugin-message-edit
- `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml`, and that patch file is committed.
- `lib/client.js` is committed rather than produced at publish time, so a `github:` install works without a build step.
- Also published to npm as `dsh-plugin-message-edit@1.0.0` (MIT), with `repository.url` pointing back at this repo.
- Category `session`: it operates on sent messages and conversation branches.

Tested locally against DSH Desktop before submitting.