### PR TITLE
Add dsh-blue/blue (ui): plugin-tree terminal UI

### DIFF
--- a/catalog/plugins/dsh-blue--blue.json
+++ b/catalog/plugins/dsh-blue--blue.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "dsh-blue/blue",
+  "name": "blue",
+  "repository": "https://github.com/dsh-blue/blue",
+  "category": "ui",
+  "description": {
+    "en": "Plugin-tree terminal UI: streaming markdown transcript, tool cards, fuzzy slash commands, and live theming, with every component a hot-swappable Cordis plugin.",
+    "zh": "插件树式终端界面：流式 markdown 会话流、工具卡片、模糊命令补全与主题热切换，每个界面组件都是可热替换的 Cordis 插件。"
+  },
+  "added": "2026-08-23"
+}


### PR DESCRIPTION
Adds one new catalog entry per CONTRIBUTING (exactly one `catalog/plugins/*.json`, no other paths touched):

- `dsh-blue/blue` — plugin-tree terminal UI for DeepSeek Harness: streaming markdown transcript, tool cards, fuzzy slash-command completion, live theming; every UI component is a hot-swappable Cordis plugin.
- The `dsh.bundle` manifest lives in the monorepo subpackage `packages/bundle/blue/package.json` (patch `cordis.patch.yml` committed alongside); the package is published on npm (`@dsh-blue/blue`, `rc` dist-tag) with `repository.url` + `repository.directory` pointing back at the subpackage, so the npm install path is the verified one: `dsh plugin --profile blue add @dsh-blue/blue@rc`.
- Docs: https://dsh-blue.dev (bilingual) · MIT · topic `dsh-plugin` set.

Descriptions are factual and mirror the repo README's own wording.