### PR TITLE
Add welsione/dsh-model-router (model): unified model routing

### DIFF
--- a/catalog/plugins/welsione--dsh-model-router.json
+++ b/catalog/plugins/welsione--dsh-model-router.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "welsione/dsh-model-router",
+  "name": "dsh-model-router",
+  "repository": "https://github.com/welsione/dsh-model-router",
+  "category": "model",
+  "description": {
+    "en": "Unified model routing for DeepSeek Harness: one logical ModelID backed by multiple providers' equivalent models, with first-token failover and cooldown, health-aware candidate ranking, three tiers (tier1/tier2/tier3) auto-selected by purpose, per-candidate reasoning effort, and a settings-page management panel.",
+    "zh": "统一模型路由：一个逻辑 ModelID 汇聚多家供应商的同名模型，首 token 前失败自动切换并进入冷却、健康度择优、按 purpose 三档分级（tier1/tier2/tier3）、每候选思考级别，设置面板自动保存即时生效。"
+  },
+  "added": "2026-08-23"
+}


### PR DESCRIPTION
Adds [welsione/dsh-model-router](https://github.com/welsione/dsh-model-router) to the catalog (single new entry).

**What it does:** unified model routing for DeepSeek Harness — one logical ModelID backed by multiple providers' equivalent models, with first-token failover and cooldown, health-aware candidate ranking, three tiers (tier1/tier2/tier3) auto-selected by purpose, per-candidate reasoning effort, and a settings-page management panel.

**Checklist (per CONTRIBUTING):**
- [x] One new `catalog/plugins/welsione--dsh-model-router.json` only (no other paths touched)
- [x] `package.json` declares `dsh.bundle.patch` → `cordis.patch.yml`, committed
- [x] Installs from GitHub: entry points (`lib/`) are committed, so no build-artifact trap
- [x] Also published to npm (`@welsione/dsh-model-router@0.0.2`) with `repository` pointing back to this repo → will be labelled verified
- [x] `dsh-plugin` GitHub topic set
- [x] Descriptions factual, neutral, specific (no superlatives)
- [x] `category: model` matches routing purpose
- [x] `added: 2026-08-23`

Note: this is distinct from the unrelated unscoped npm `dsh-model-router@0.6.2` (thedeveloper256); this entry's `id` `welsione/dsh-model-router` and scoped npm name disambiguate it.
