### PR TITLE
catalog: add haoku123/dsh-voice plugin entry

### DIFF
--- a/catalog/plugins/haoku123--dsh-voice.json
+++ b/catalog/plugins/haoku123--dsh-voice.json
@@ -3,7 +3,7 @@
   "id": "haoku123/dsh-voice",
   "name": "dsh-voice",
   "repository": "https://github.com/haoku123/dsh-voice",
-  "category": "voice",
+  "category": "tools",
   "description": {
     "en": "Full-duplex voice for the DSH Web UI: tap-to-toggle or hold-to-talk dictation (send key or Ctrl) with a live caption, host-side SenseVoice ASR via sherpa-onnx, sentence-by-sentence spoken replies, and true barge-in where speaking interrupts playback and the running turn. Includes NLMS acoustic echo cancellation using the page's own TTS playback as the echo reference. No API key.",
     "zh": "DSH Web UI 全双工语音对话：点按切换或按住说话（发送键或 Ctrl）并显示实时字幕，宿主端 SenseVoice（sherpa-onnx）转写，回复按句流式朗读，开口说话即打断播放与正在运行的回合（真 barge-in）。内置 NLMS 声学回声消除，以页面自身 TTS 播放为回声参考。无需 API key。"

--- a/catalog/plugins/haoku123--dsh-voice.json
+++ b/catalog/plugins/haoku123--dsh-voice.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "haoku123/dsh-voice",
+  "name": "dsh-voice",
+  "repository": "https://github.com/haoku123/dsh-voice",
+  "category": "voice",
+  "description": {
+    "en": "Full-duplex voice for the DSH Web UI: tap-to-toggle or hold-to-talk dictation (send key or Ctrl) with a live caption, host-side SenseVoice ASR via sherpa-onnx, sentence-by-sentence spoken replies, and true barge-in where speaking interrupts playback and the running turn. Includes NLMS acoustic echo cancellation using the page's own TTS playback as the echo reference. No API key.",
+    "zh": "DSH Web UI 全双工语音对话：点按切换或按住说话（发送键或 Ctrl）并显示实时字幕，宿主端 SenseVoice（sherpa-onnx）转写，回复按句流式朗读，开口说话即打断播放与正在运行的回合（真 barge-in）。内置 NLMS 声学回声消除，以页面自身 TTS 播放为回声参考。无需 API key。"
+  },
+  "added": "2026-08-23"
+}


### PR DESCRIPTION
Add a catalog entry for the [dsh-voice](https://github.com/haoku123/dsh-voice) plugin.

- **id**: `haoku123/dsh-voice`
- **category**: voice
- **`dsh.bundle.patch`**: declared (`./cordis.patch.yml`, committed)
- **GitHub topic**: `dsh-plugin` already set
- **npm**: published as `@haoku123/dsh-voice` (v0.8.0), `repository.url` points back at this plugin

Description kept factual/neutral per CONTRIBUTING. Single new file under `catalog/plugins/` only.