### PR TITLE
Add liang-today/dsh-liangxiang

### DIFF
--- a/catalog/plugins/liang-today--dsh-liangxiang.json
+++ b/catalog/plugins/liang-today--dsh-liangxiang.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "liang-today/dsh-liangxiang",
+  "name": "dsh-liangxiang",
+  "repository": "https://github.com/liang-today/dsh-liangxiang",
+  "category": "fun",
+  "description": {
+    "en": "Burned DSH tokens become incense; spend one stick to raise or lower today's case. The case updates daily, Liangwei decides today's Liangzi, and the result is archived at day end.",
+    "zh": "用 DSH 烧掉的 Token 凝成香火，花一炷给今日梁案投夯或拉；梁案每日更新，梁位决定今日梁子，日终收入梁祠。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
Add `liang-today/dsh-liangxiang` to the catalog.

- id: `liang-today/dsh-liangxiang`
- category: `fun`
- public repo with `dsh-plugin` topic and `dsh.bundle.patch`
- published on npm as `dsh-liangxiang`


Made with [Cursor](https://cursor.com)