### PR TITLE
catalog: add yu502950715yang/dsh-use-wallpaper

### DIFF
--- a/catalog/plugins/yu502950715yang--dsh-use-wallpaper.json
+++ b/catalog/plugins/yu502950715yang--dsh-use-wallpaper.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "yu502950715yang/dsh-use-wallpaper",
+  "name": "dsh-use-wallpaper",
+  "repository": "https://github.com/yu502950715yang/dsh-use-wallpaper",
+  "category": "theme",
+  "description": {
+    "en": "Renders Wallpaper Engine wallpapers as the DeepSeek Harness web background: scene wallpapers are drawn live by a Rust/WebGPU (wasm) renderer (image objects and GPU particles), video wallpapers loop, web wallpapers load in a sandboxed iframe, and everything else falls back to a preview image with Ken Burns. No Wallpaper Engine runtime required.",
+    "zh": "把 Wallpaper Engine 壁纸渲染为 DeepSeek Harness 的 Web 背景：scene 壁纸由 Rust/WebGPU（wasm）渲染器实时绘制（图片对象 + GPU 粒子），视频壁纸循环播放，web 壁纸用沙箱 iframe 加载，其余回退 preview 图 + Ken Burns；无需 Wallpaper Engine 运行时。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
提交 `dsh-use-wallpaper` 插件到目录。

### 提交确认
- **插件 ID**：`yu502950715yang/dsh-use-wallpaper`（仓库级）
- **仓库**：https://github.com/yu502950715yang/dsh-use-wallpaper
- **分类**：`theme`（主题与外观）
- **前置门槛**：`package.json` 声明 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件已提交；仓库已加 `dsh-plugin` topic。
- **安装可用性**：当前未发布 npm 包，收录后为浏览模式；发布 npm 包后目录自动检测。

### 作者自测
- `pnpm run build`（tsc strict）通过
- `pnpm run build:client`（esbuild + wasm/粒子纹理复制）通过
- 已在 DSH Web GUI 验证 scene（wasm 渲染）/视频/web/preview 回退路径

### 范围
本次 PR 仅新增一个目录文件 `catalog/plugins/yu502950715yang--dsh-use-wallpaper.json`。