### PR TITLE
Add jinzheng8115/dsh-Minesweeper

### DIFF
--- a/catalog/plugins/jinzheng8115--dsh-minesweeper.json
+++ b/catalog/plugins/jinzheng8115--dsh-minesweeper.json
@@ -3,7 +3,7 @@
   "id": "jinzheng8115/dsh-Minesweeper",
   "name": "dsh-Minesweeper",
   "repository": "https://github.com/jinzheng8115/dsh-Minesweeper",
-  "category": "games",
+  "category": "fun",
   "description": {
     "en": "Minesweeper plugin for DeepSeek Harness: agent tool set and a human web panel sharing the same board. Supports reveal, flag, chord, a deterministic auto-solver and batch moves; three preset difficulties plus custom sizes.",
     "zh": "DeepSeek Harness 扫雷插件：agent 工具集与人类网页面板共享同一棋盘，支持挖开、插旗、快翻、确定性自动求解与批量落子；三种预设难度加自定义尺寸。"

--- a/catalog/plugins/jinzheng8115--dsh-minesweeper.json
+++ b/catalog/plugins/jinzheng8115--dsh-minesweeper.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "jinzheng8115/dsh-Minesweeper",
+  "name": "dsh-Minesweeper",
+  "repository": "https://github.com/jinzheng8115/dsh-Minesweeper",
+  "category": "games",
+  "description": {
+    "en": "Minesweeper plugin for DeepSeek Harness: agent tool set and a human web panel sharing the same board. Supports reveal, flag, chord, a deterministic auto-solver and batch moves; three preset difficulties plus custom sizes.",
+    "zh": "DeepSeek Harness 扫雷插件：agent 工具集与人类网页面板共享同一棋盘，支持挖开、插旗、快翻、确定性自动求解与批量落子；三种预设难度加自定义尺寸。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
Adds `catalog/plugins/jinzheng8115--dsh-minesweeper.json`.

- **id**: `jinzheng8115/dsh-Minesweeper`
- **repository**: https://github.com/jinzheng8115/dsh-Minesweeper
- **category**: `games`
- **dsh.bundle.patch**: declared in `package.json`, patch file (`cordis.patch.yml`) committed at repo root ✅
- **npm**: not yet published — listed browse-only until published
- **topic** `dsh-plugin`: added to the source repository ✅

Plugin: Minesweeper with agent tool set + human web panel sharing one board (reveal / flag / chord / auto-solver / batch moves), three preset difficulties + custom sizes.