### PR TITLE
catalog: add dsh-response-window (Web UI response-window slides)

### DIFF
--- a/catalog/plugins/heiheiha798--dsh-response-window.json
+++ b/catalog/plugins/heiheiha798--dsh-response-window.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "heiheiha798/dsh-response-window",
+  "name": "dsh-response-window",
+  "repository": "https://github.com/heiheiha798/dsh-response-window",
+  "category": "ui",
+  "description": {
+    "en": "Web UI plugin that folds each staged response's think and tool calls into per-segment slide windows with a configurable bounded height and inner scrolling, keeping every intermediate response visible.",
+    "zh": "Web UI 插件：以阶段性文字回复为界分段，把每段的 think 与工具调用收进限高可滚动、高度可配置的 slide 窗口，中间过程始终可见。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
Adds one new catalog entry for the DSH Web UI plugin **`dsh-response-window`** (`heiheiha798/dsh-response-window`).

- Single new `catalog/plugins/*.json` file, nothing else touched.
- Category: `ui`.
- The plugin repo declares `dsh.bundle.patch: ./cordis.patch.yml` (patch file committed) and carries the `dsh.plugin.json` manifest.
- Description: folds each staged response's think + tool calls into per-segment bounded, scrollable slide windows (configurable height), keeping intermediate responses visible.