### PR TITLE
catalog: add MemSearch

### DIFF
--- a/catalog/plugins/zilliztech--memsearch--plugins--dsh.json
+++ b/catalog/plugins/zilliztech--memsearch--plugins--dsh.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zilliztech/memsearch/plugins/dsh",
+  "name": "memsearch-dsh",
+  "repository": "https://github.com/zilliztech/memsearch",
+  "category": "memory",
+  "description": {
+    "en": "Shared Markdown memory for DSH and other coding agents, with automatic capture, pre-step context injection, searchable recall, and a review panel.",
+    "zh": "供 DSH 与其他编程 Agent 共享的 Markdown 记忆，支持自动捕获、步骤前上下文注入、搜索召回与审阅面板。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
## Plugin

https://github.com/zilliztech/memsearch

Adds the repository DSH subpackage, which provides shared Markdown memory with capture, context injection, searchable recall, and a review panel.

## Author verification

- `npm test` in `plugins/dsh`: 41 tests passed
- `npm view @zilliz/memsearch-dsh version`: 0.1.3
- local catalog review: `PASS zilliztech/memsearch/plugins/dsh` and `VERDICT auto-merge`

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] This PR adds exactly one new entry
- [x] The repository declares `dsh.bundle.patch` and commits its patch file
- [x] Plugin behavior and compatibility were tested
- [x] The `dsh-plugin` topic is present
- [x] English and Chinese descriptions are neutral and accurate

cc @imsai-sh