### PR TITLE
catalog: add dsh-milvus

### DIFF
--- a/catalog/plugins/zilliztech--dsh-milvus.json
+++ b/catalog/plugins/zilliztech--dsh-milvus.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zilliztech/dsh-milvus",
+  "name": "dsh-milvus",
+  "repository": "https://github.com/zilliztech/dsh-milvus",
+  "category": "tools",
+  "description": {
+    "en": "Read-only DSH Web plugin for inspecting and searching Milvus or Zilliz Cloud collections from chat, including scalar, BM25, dense, and hybrid queries.",
+    "zh": "只读 DSH Web 插件，可在对话中检查和搜索 Milvus 或 Zilliz Cloud Collection，支持标量、BM25、稠密向量与混合查询。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
## Plugin

https://github.com/zilliztech/dsh-milvus

Adds a read-only DSH Web plugin for inspecting and searching Milvus or Zilliz Cloud collections with scalar, BM25, dense, and hybrid queries.

## Author verification

- `npm test`: 80 tests passed; 16 credentialed integration tests skipped
- `npm view @zilliz/dsh-milvus version`: 0.1.3
- local catalog review: `PASS zilliztech/dsh-milvus` and `VERDICT auto-merge`

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] This PR adds exactly one new entry
- [x] The repository declares `dsh.bundle.patch` and commits its patch file
- [x] Plugin behavior and compatibility were tested
- [x] The `dsh-plugin` topic is present
- [x] English and Chinese descriptions are neutral and accurate

cc @imsai-sh