### PR TITLE
catalog: add moyuer233/dsh-deepseek-monitor

### DIFF
--- a/catalog/plugins/moyuer233--dsh-deepseek-monitor.json
+++ b/catalog/plugins/moyuer233--dsh-deepseek-monitor.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "moyuer233/dsh-deepseek-monitor",
+  "name": "dsh-deepseek-monitor",
+  "repository": "https://github.com/moyuer233/dsh-deepseek-monitor",
+  "category": "model",
+  "description": {
+    "en": "A DeepSeek Harness plugin that shows DeepSeek account balance, token usage and cost for today/month/all-time in the chat UI, with draggable panel order settings and an optional local proxy that records API usage.",
+    "zh": "DeepSeek Harness 插件，在聊天界面展示 DeepSeek 账户余额、今日/本月/累计 token 用量与费用，支持拖拽排序面板配置，并提供可选的本地代理记录 API 用量。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
## Summary

Add [`moyuer233/dsh-deepseek-monitor`](https://github.com/moyuer233/dsh-deepseek-monitor) to the DeepSeek Harness plugin catalog.

## Plugin verification

- Manifest: `package.json`
- Bundle patch: `cordis.patch.yml`
- Test command: `node test/self-test.mjs && node test/service-test.mjs`
- Test result: all checks passed (self-test 18/18, service-test 25/25; both are mock-based and do not call the real platform)

## Catalog submission confirmation

- [x] This PR adds exactly one `catalog/plugins/*.json` file and no other changes
- [x] The plugin repository declares `dsh.bundle.patch` and the referenced patch file is committed
- [x] The author has tested plugin behavior and compatibility
- [x] The plugin repository has the `dsh-plugin` topic
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that failed reviews keep the PR open for fixes, non-draft PRs are auto-merged after passing, merged entries are synced by CI to the website catalog and README, and inclusion is not an endorsement of plugin behavior, security, or quality
