### PR TITLE
Add Hoemr/dsh-quicklook

### DIFF
--- a/catalog/plugins/hoemr--dsh-quicklook.json
+++ b/catalog/plugins/hoemr--dsh-quicklook.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "../schema/plugin.schema.json",
   "id": "Hoemr/dsh-quicklook",
   "name": "dsh-quicklook",

--- a/catalog/plugins/hoemr--dsh-quicklook.json
+++ b/catalog/plugins/hoemr--dsh-quicklook.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Hoemr/dsh-quicklook",
+  "name": "dsh-quicklook",
+  "repository": "https://github.com/Hoemr/dsh-quicklook",
+  "category": "ui",
+  "description": {
+    "en": "QuickLook-style space-key preview overlay for DSH better-sidebar: press Space on the active file tab for a full-size view of images, PDFs, and text files; Space or Escape closes.",
+    "zh": "为 DSH better-sidebar 提供类 QuickLook 的空格键预览：在活动文件标签页按 Space 即可全尺寸查看图片、PDF 与文本文件，Space 或 Escape 关闭。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
## Add Hoemr/dsh-quicklook

- Repository: https://github.com/Hoemr/dsh-quicklook
- Category: ui
- What it does: QuickLook-style space-key preview overlay for DSH better-sidebar - press Space on the active file tab for a full-size image/PDF/text overlay; Space or Escape closes.
- The repository root package.json declares a non-empty dsh.bundle.patch pointing to the committed cordis.patch.yml.
- npm package dsh-quicklook@0.1.0 is being published (author-run); install command will appear once live per catalog auto-detection.
- Plugin self-tested by the author on DSH Desktop rc builds; runtime compatibility is author-maintained.