### PR TITLE
catalog: rename smart-subagent to evo-subagent

### DIFF
--- a/catalog/plugins/zekaishi--evo-subagent.json
+++ b/catalog/plugins/zekaishi--evo-subagent.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../schema/plugin.schema.json",
-  "id": "ZekaiShi/smart-subagent",
-  "name": "smart-subagent",
-  "repository": "https://github.com/ZekaiShi/smart-subagent",
+  "id": "ZekaiShi/evo-subagent",
+  "name": "evo-subagent",
+  "repository": "https://github.com/ZekaiShi/evo-subagent",
   "category": "model",
   "description": {
     "en": "Maps a stable agent_key to an exact provider/model pair declared in role Markdown files, with per-workspace evolution of prefercmd and memory files.",


### PR DESCRIPTION
## Plugin

[ZekaiShi/evo-subagent](https://github.com/ZekaiShi/evo-subagent) provides strict per-subagent provider/model routing from role Markdown front matter and per-workspace evolution files. This PR updates the existing catalog entry after the repository and npm package were renamed from `smart-subagent` to `evo-subagent`.

## Author verification

- `npm run check`: passed
- `npm test`: 87/87 tests passed
- `npm publish --dry-run --access public`: passed for `evo-subagent@0.5.0`

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [ ] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [x] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically

## Maintainer API compatibility

Catalog-only plugin submission; no marketplace API behavior is changed.