### PR TITLE
catalog: add GooDAnDReaDY/dsh-image-gen

### DIFF
--- a/catalog/plugins/goodandready--dsh-image-gen.json
+++ b/catalog/plugins/goodandready--dsh-image-gen.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "GooDAnDReaDY/dsh-image-gen",
+  "name": "dsh-image-gen",
+  "repository": "https://github.com/GooDAnDReaDY/dsh-image-gen",
+  "category": "tools",
+  "description": {
+    "en": "Adds a generate_image tool backed by the FAL queue, any OpenAI-compatible images API, or a ChatGPT/Grok subscription, and shows the result inline in the conversation.",
+    "zh": "提供 generate_image 工具，可接入 FAL 队列、任意 OpenAI 兼容图像 API 或 ChatGPT/Grok 订阅，并在对话中内联显示结果。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
One new catalog entry for [`GooDAnDReaDY/dsh-image-gen`](https://github.com/GooDAnDReaDY/dsh-image-gen).

- `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`, committed).
- Published on npm as `@goodandready/dsh-image-gen`.
- Repository carries the `dsh-plugin` topic.
- Entry validated locally with `scripts/lib/catalog-entry.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)