### PR TITLE
catalog: add GooDAnDReaDY/dsh-model-sync

### DIFF
--- a/catalog/plugins/goodandready--dsh-model-sync.json
+++ b/catalog/plugins/goodandready--dsh-model-sync.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "GooDAnDReaDY/dsh-model-sync",
+  "name": "dsh-model-sync",
+  "repository": "https://github.com/GooDAnDReaDY/dsh-model-sync",
+  "category": "model",
+  "description": {
+    "en": "Synchronizes the model catalog of API-key providers from the provider itself instead of maintaining the model list by hand.",
+    "zh": "自动从服务商同步 API Key 提供方的模型列表，无需手动维护。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
One new catalog entry for [`GooDAnDReaDY/dsh-model-sync`](https://github.com/GooDAnDReaDY/dsh-model-sync).

- `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`, committed).
- Published on npm as `@goodandready/dsh-model-sync`.
- Repository carries the `dsh-plugin` topic.
- Entry validated locally with `scripts/lib/catalog-entry.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)