### PR TITLE
catalog: add GooDAnDReaDY/dsh-russian-lang

### DIFF
--- a/catalog/plugins/goodandready--dsh-russian-lang.json
+++ b/catalog/plugins/goodandready--dsh-russian-lang.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "GooDAnDReaDY/dsh-russian-lang",
+  "name": "dsh-russian-lang",
+  "repository": "https://github.com/GooDAnDReaDY/dsh-russian-lang",
+  "category": "ui",
+  "description": {
+    "en": "Russian localization for the web UI: adds a third option to Settings - General - Language and translates the core and plugin locale namespaces at runtime.",
+    "zh": "Web UI 俄语本地化：在 设置 - 通用 - 语言 中增加第三个选项，并在运行时翻译核心与插件的语言命名空间。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
One new catalog entry for [`GooDAnDReaDY/dsh-russian-lang`](https://github.com/GooDAnDReaDY/dsh-russian-lang).

- `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`, committed).
- Published on npm as `@goodandready/dsh-russian-lang`.
- Repository carries the `dsh-plugin` topic.
- Entry validated locally with `scripts/lib/catalog-entry.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)