### PR TITLE
catalog: add GooDAnDReaDY/dsh-subscriptions

### DIFF
--- a/catalog/plugins/goodandready--dsh-subscriptions.json
+++ b/catalog/plugins/goodandready--dsh-subscriptions.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "GooDAnDReaDY/dsh-subscriptions",
+  "name": "dsh-subscriptions",
+  "repository": "https://github.com/GooDAnDReaDY/dsh-subscriptions",
+  "category": "model",
+  "description": {
+    "en": "Registers ChatGPT Codex, Claude, Grok and Antigravity subscriptions as LLM providers through OAuth, without an API key.",
+    "zh": "通过 OAuth 将 ChatGPT Codex、Claude、Grok 与 Antigravity 订阅注册为 LLM 提供方，无需 API Key。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
One new catalog entry for [`GooDAnDReaDY/dsh-subscriptions`](https://github.com/GooDAnDReaDY/dsh-subscriptions).

- `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`, committed).
- Published on npm as `@goodandready/dsh-subscriptions`.
- Repository carries the `dsh-plugin` topic.
- Entry validated locally with `scripts/lib/catalog-entry.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)