### PR TITLE
catalog: add GooDAnDReaDY/dsh-tts

### DIFF
--- a/catalog/plugins/goodandready--dsh-tts.json
+++ b/catalog/plugins/goodandready--dsh-tts.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "GooDAnDReaDY/dsh-tts",
+  "name": "dsh-tts",
+  "repository": "https://github.com/GooDAnDReaDY/dsh-tts",
+  "category": "tools",
+  "description": {
+    "en": "Speaks agent replies in the web UI through a provider fallback chain (OpenAI, ElevenLabs, Google, Azure, Groq, Deepgram, OpenRouter, Edge, Piper, eSpeak).",
+    "zh": "在 Web UI 中朗读智能体回复，支持服务商回退链（OpenAI、ElevenLabs、Google、Azure、Groq、Deepgram、OpenRouter、Edge、Piper、eSpeak）。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
One new catalog entry for [`GooDAnDReaDY/dsh-tts`](https://github.com/GooDAnDReaDY/dsh-tts).

- `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`, committed).
- Published on npm as `@goodandready/dsh-tts`.
- Repository carries the `dsh-plugin` topic.
- Entry validated locally with `scripts/lib/catalog-entry.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)