### PR TITLE
catalog: add GooDAnDReaDY/dsh-vision-bridge

### DIFF
--- a/catalog/plugins/goodandready--dsh-vision-bridge.json
+++ b/catalog/plugins/goodandready--dsh-vision-bridge.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "GooDAnDReaDY/dsh-vision-bridge",
+  "name": "dsh-vision-bridge",
+  "repository": "https://github.com/GooDAnDReaDY/dsh-vision-bridge",
+  "category": "tools",
+  "description": {
+    "en": "Routes images to a vision model of your choice - auto-rewrite, explicit tools, or hybrid - so a text-only chat model does not fail a turn that contains a picture.",
+    "zh": "将图片交给所选的视觉模型处理（自动改写、显式工具或混合模式），使纯文本聊天模型也能处理包含图片的对话。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
One new catalog entry for [`GooDAnDReaDY/dsh-vision-bridge`](https://github.com/GooDAnDReaDY/dsh-vision-bridge).

- `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`, committed).
- Published on npm as `@goodandready/dsh-vision-bridge`.
- Repository carries the `dsh-plugin` topic.
- Entry validated locally with `scripts/lib/catalog-entry.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)