### PR TITLE
catalog: add GooDAnDReaDY/dsh-voice

### DIFF
--- a/catalog/plugins/goodandready--dsh-voice.json
+++ b/catalog/plugins/goodandready--dsh-voice.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "GooDAnDReaDY/dsh-voice",
+  "name": "dsh-voice",
+  "repository": "https://github.com/GooDAnDReaDY/dsh-voice",
+  "category": "tools",
+  "description": {
+    "en": "Voice input for the web UI: dictation chunked by pauses and voice messages, each with its own provider fallback chain (Deepgram, Groq, HuggingFace, local whisper.cpp, or an OpenAI-compatible endpoint).",
+    "zh": "Web UI 语音输入：按停顿分段的听写与语音消息，各自拥有独立的服务商回退链（Deepgram、Groq、HuggingFace、本地 whisper.cpp 或 OpenAI 兼容接口）。"
+  },
+  "added": "2026-08-24"
+}


### PR DESCRIPTION
One new catalog entry for [`GooDAnDReaDY/dsh-voice`](https://github.com/GooDAnDReaDY/dsh-voice).

- `package.json` declares a non-empty `dsh.bundle.patch` (`./cordis.patch.yml`, committed).
- Published on npm as `@goodandready/dsh-voice`.
- Repository carries the `dsh-plugin` topic.
- Entry validated locally with `scripts/lib/catalog-entry.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)