### PR TITLE
catalog: add JustinQiuck/dsh-freecanvas/plugins/dsh-freecanvas

### DIFF
--- a/catalog/plugins/justinqiuck--dsh-freecanvas--plugins--dsh-freecanvas.json
+++ b/catalog/plugins/justinqiuck--dsh-freecanvas--plugins--dsh-freecanvas.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "JustinQiuck/dsh-freecanvas/plugins/dsh-freecanvas",
+  "name": "dsh-freecanvas",
+  "repository": "https://github.com/JustinQiuck/dsh-freecanvas",
+  "category": "workflow",
+  "description": {
+    "en": "Bundles an AI infinite canvas into DSH with built-in Web assets, local Canvas Agent connectivity, image and video workspaces, and visual content orchestration.",
+    "zh": "将 AI 无限画布作为自包含 DSH bundle 集成，内置 Web 资源、本地 Canvas Agent 连接、生图与视频工作台及可视化内容编排。"
+  },
+  "added": "2026-08-25"
+}


### PR DESCRIPTION
## 摘要

将 [JustinQiuck/dsh-freecanvas/plugins/dsh-freecanvas](https://github.com/JustinQiuck/dsh-freecanvas) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：plugins/dsh-freecanvas/package.json
- 子目录：plugins/dsh-freecanvas（其 package.json 即插件 manifest）
- Bundle patch：plugins/dsh-freecanvas/cordis.patch.yml
- 测试命令：npm --prefix plugins/dsh-freecanvas run verify:dsh-install
- 测试结果：DSH FreeCanvas Package run 32775248308 通过；0.2.0 发布候选完成 package、host、干净 profile 安装、重复安装、启动与卸载验证，npm registry tarball SHA256 与候选 a07e62c2e61ac78ef0ddc139aec084b227139adc0c639e9f4547fc2aed884542 一致，137 个包的 registry signatures 审计通过。

## 目录提交确认

- [x] 本 PR 只新增一个 catalog/plugins/*.json 文件，不包含其他改动
- [x] 插件仓库声明了 dsh.bundle.patch，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 dsh-plugin topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书