### PR TITLE
catalog: add key8023lala/dsh-ark-balance

### DIFF
--- a/catalog/plugins/key8023lala--dsh-ark-balance.json
+++ b/catalog/plugins/key8023lala--dsh-ark-balance.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "key8023lala/dsh-ark-balance",
+  "name": "dsh-ark-balance",
+  "repository": "https://github.com/key8023lala/dsh-ark-balance",
+  "category": "ui",
+  "description": {
+    "en": "Draggable DSH web widget showing remaining free-inference and data-permission quota for Volcano Engine Ark collaboration reward plan models, with type/vendor filtering, sorting, and 60-second auto-refresh. Data is read from the official arkcli CLI; the plugin reuses its login state and does not store credentials.",
+    "zh": "在 DSH Web 界面以可拖拽挂件展示火山引擎方舟协作奖励计划各模型的免费推理与数据权限资源包余量（总量/已用/剩余），支持类型与厂商筛选、排序和 60 秒自动刷新。数据来自官方 arkcli 命令，插件复用其登录态，不保存任何凭据。"
+  },
+  "added": "2026-08-25"
+}


### PR DESCRIPTION
## Plugin

**Repository:** https://github.com/key8023lala/dsh-ark-balance

**User-visible capability:** a draggable floating widget in the DSH Web UI that shows the remaining free-inference and data-permission quota (total / used / remaining, plus release date) for Volcano Engine Ark collaboration reward plan models. It supports type/vendor multi-select filtering, sorting, and 60-second auto-refresh, and reads its data from the official `arkcli` CLI (reusing its login state; no credentials stored by the plugin).

## Author verification

Commands and results used to verify the plugin and its installability:

| Check | Command | Result |
| --- | --- | --- |
| Manifest declares `dsh.bundle.patch` and the patch is committed | GitHub tree inspection of `key8023lala/dsh-ark-balance@main` (API) | `package.json` declares `dsh.bundle.patch: "./cordis.patch.yml"`; `cordis.patch.yml` exists in the repo tree |
| Published npm package (1024 Store installs from npm only) | `registry.npmjs.org/dsh-ark-balance` | `dsh-ark-balance@0.1.0` published (last modified 2026-08-24) |
| Plugin code parses | `node --check lib/index.js` and `node --check lib/widget.js` | both pass |
| `dsh-plugin` GitHub topic | GitHub API repository metadata | topic `dsh-plugin` present |
| `arkcli` login state | `arkcli auth status --format json` | `logged_in: true`, `auth_method: sso`, identity `volc-2104621987` (root) |
| Free-quota data source works | `arkcli usage balance --type free-quota --format json --page-size 200` | returns 43 model items with `FreeInference` / `DataPermission` resource packs |
| Live routes (plugin installed in the `web` profile) | `GET http://127.0.0.1:3080/dsh-ark/status.json` | `200` `{"installed":true,"authed":true,"version":"1.0.20"}` |
| Live routes (plugin installed in the `web` profile) | `GET http://127.0.0.1:3080/dsh-ark/balance.json` | `200` `{"ok":true,"data":{...43 items...}}` — matches the direct `arkcli` output |
| Live routes (plugin installed in the `web` profile) | `GET http://127.0.0.1:3080/dsh-ark/plan.json` | `200` `{"ok":true,...}` |
| Live routes (plugin installed in the `web` profile) | `GET http://127.0.0.1:3080/dsh-ark/widget.js` | `200`, widget IIFE served (36,988 bytes) |

The plugin was already installed in the `web` profile (`dsh-ark-balance@0.1.0` present in `dsh.profile.bundles`), so the runtime verification above exercises the exact published npm package and the live `dsh web` host, not a dev link.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically

## Maintainer API compatibility

Catalog-only plugin submissions leave this section unchecked.

- [ ] This change has no API behavior impact, or its API impact is described above
- [ ] Every added or changed API route is registered in `apps/web/contracts/api-surface.json`
- [ ] Existing-version behavior remains backward compatible and historical contract fixtures were not casually rewritten
- [ ] Any breaking behavior uses a new versioned route while the previous version remains available
- [ ] `npm run test:api-contract` passes
