### PR TITLE
fix(dsh1024): keep a live bridge when the storefront 'load' fires late

### DIFF
--- a/packages/dsh1024/client/client.js
+++ b/packages/dsh1024/client/client.js
@@ -544,6 +544,10 @@ function MarketShell({ locale, onClose, activation }) {
   }, [connectFrame, embedUrl])
 
   const frameLoaded = useCallback(() => {
+    // A fast storefront can complete the bridge before the iframe's 'load'
+    // event fires; tearing the port down here would kill a live connection.
+    // Only reset when no bridge is established yet.
+    if (portRef.current !== null) return
     closeBridge()
     setConnection('connecting')
     readyTimerRef.current = window.setTimeout(() => setConnection('failed'), READY_TIMEOUT_MS)


### PR DESCRIPTION
## Problem

The 1024 Store panel opens, the storefront is briefly visible, then the client swaps in the "商店页面未能加载" fallback after ~5s.

Root cause is a race in `packages/dsh1024/client/client.js`: the storefront completes the v1 bridge handshake (init → connect → ready) while the iframe's `load` event is still pending (the page loads fast from CDN/cache, but `load` waits for every subresource, including the external telemetry script). When `load` finally fires, `frameLoaded` unconditionally calls `closeBridge()`, which closes the just-established MessageChannel port and resets the connection — so no further `ready` can arrive and the 5s READY_TIMEOUT flips the panel to the fallback.

It is timing-dependent: a cold first load sends `init` after `load` (works), while a warm cached storefront sends `init` before `load` (breaks). This reproduces "page shows, then disappears" reliably.

## Fix

Guard `frameLoaded` so a late `load` event cannot tear down a bridge that is already up:

```js
const frameLoaded = useCallback(() => {
  if (portRef.current !== null) return
  closeBridge()
  ...
}, [closeBridge])
```

`portRef.current` is only non-null while the handshake port is active, so this skips the teardown exactly when the connection already succeeded, and keeps the old reset path when no bridge exists yet.

## Verification

- Reproduced in a headless Chromium harness that mirrors `client.js` (listen for `init` → open MessageChannel → send `connect` → expect `ready`, plus `onload` → `closeBridge`):
  - before: `READY received -> connected` then `iframe onload fired (port: OPEN)` → `after closeBridge: port=null` → `READY TIMEOUT after load -> FAILED`
  - after the guard: `onload` sees the port open and skips teardown → stays `CONNECTED`
- `npm run test --workspace dsh1024` — 39/39 pass, preflight ok
- `npm run typecheck --workspace dsh1024` — clean