### PR TITLE
catalog: add MikumikuDAIFans/PrivateAgentSkills

### DIFF
--- a/catalog/plugins/mikumikudaifans--privateagentskills.json
+++ b/catalog/plugins/mikumikudaifans--privateagentskills.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "MikumikuDAIFans/PrivateAgentSkills",
+  "name": "PrivateAgentSkills",
+  "repository": "https://github.com/MikumikuDAIFans/PrivateAgentSkills",
+  "category": "skill",
+  "description": {
+    "en": "DeepSeek Harness skill bundle: registers the seven-skill integrated development workflow suite on ctx.skills - lifecycle routing, method selection (SDD/BDD/TDD/EDD and overlays), proportional Lite/Standard/Full planning, implementation control, evidence-based verification, review/release, and session handoff. Standard SKILL.md layout, also usable with Codex and Claude Code.",
+    "zh": "DeepSeek Harness 技能包：在 ctx.skills 上注册七技能一体化开发工作流套件——生命周期路由、方法选择（SDD/BDD/TDD/EDD 及叠加层）、Lite/Standard/Full 分级规划、实施控制、基于证据的验证、评审发布与会话交接。采用标准 SKILL.md 布局，也可用于 Codex 与 Claude Code。"
+  },
+  "added": "2026-08-26"
+}


### PR DESCRIPTION
## 摘要

将 [`MikumikuDAIFans/PrivateAgentSkills`](https://github.com/MikumikuDAIFans/PrivateAgentSkills) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`（仓库根）
- Bundle patch：`cordis.patch.yml`
- 测试命令：
  - 对 `index.js` 的 `ctx.skills` provider 做冒烟测试（注册并完整加载 7 个 skill 正文）
  - 使用目录仓库自带的 `validateCatalogEntry` 校验本 PR 的 JSON 与文件名
  - 使用目录仓库自带的 `findHarnessBundle` 模拟静态审查（分类结果：`entry_committed`）
- 测试结果：7 个 skill（integrated-development-workflow、project-lifecycle-workflow、agentic-project-development、construction-plan-system、long-task-planner、execution-launch、session-handoff）全部注册并可加载；目录 JSON 校验通过；插件仓库默认分支 `generic/integrated-development-skill-suite` 上已提交 `package.json` 与 `cordis.patch.yml`

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
