### PR TITLE
Add maxmilian/dsh-sonarqube

### DIFF
--- a/catalog/plugins/maxmilian--dsh-sonarqube.json
+++ b/catalog/plugins/maxmilian--dsh-sonarqube.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "maxmilian/dsh-sonarqube",
+  "name": "dsh-sonarqube",
+  "repository": "https://github.com/maxmilian/dsh-sonarqube",
+  "category": "dev",
+  "description": {
+    "en": "Read-only SonarQube Community Build tools: instance status, project Quality Gate for a branch or pull request, issue and Security Hotspot search, single hotspot detail, and coverage, duplication or caller-selected measures.",
+    "zh": "面向 SonarQube Community Build 的只读工具：实例状态、分支或 PR 的项目质量阈、议题与安全热点搜索、单个热点详情，以及覆盖率、重复率或调用方指定的度量项。"
+  },
+  "added": "2026-08-26"
+}


### PR DESCRIPTION
Adds one new catalog entry: [maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube), category `dev`.

Read-only DeepSeek Harness plugin for the SonarQube Community Build Web API. Six read-only tools: instance status, project Quality Gate for the main analysis / a branch / a pull request, issue search, Security Hotspot search, single hotspot detail, and coverage, duplication or caller-selected measures. Issue and hotspot results carry a normalized location with component key, file path, line and text range.

- Root `package.json` declares `dsh.bundle.patch` → `./cordis.patch.yml`, which exists in the same revision
- Published to npm as `dsh-sonarqube`, so store installs are prebuilt
- MIT, `dsh-plugin` topic, CI runs lint, typecheck, 45 tests and a pack smoke test
- Live compatibility validated against SonarQube Community Build 26.8.0.126808

Only `catalog/plugins/maxmilian--dsh-sonarqube.json` is touched.