### PR TITLE
Add maxmilian/dsh-odoo

### DIFF
--- a/catalog/plugins/maxmilian--dsh-odoo.json
+++ b/catalog/plugins/maxmilian--dsh-odoo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "maxmilian/dsh-odoo",
+  "name": "dsh-odoo",
+  "repository": "https://github.com/maxmilian/dsh-odoo",
+  "category": "tools",
+  "description": {
+    "en": "Read-only Odoo tools over JSON-RPC: server info, model field introspection, and a restricted search_read limited to an allow list of models with domain field names that may not contain dots. An opt-in draft-create tool is registered only when allowWrite is enabled, and is limited to sale.order and project.task.",
+    "zh": "经 JSON-RPC 的 Odoo 只读工具：服务器信息、模型字段自省，以及受限的 search_read（仅限白名单模型，domain 字段名不允许包含点号）。草稿创建工具需显式开启 allowWrite 才会注册，且仅限 sale.order 与 project.task。"
+  },
+  "added": "2026-08-27"
+}


### PR DESCRIPTION
Adds one new catalog entry for `maxmilian/dsh-odoo`.

- `package.json` declares a non-empty `dsh.bundle.patch` pointing at a committed `cordis.patch.yml`.
- Published to npm as `dsh-odoo` (v0.1.0), so the install path is available.
- The `dsh-plugin` GitHub topic is set.
- Only `catalog/plugins/maxmilian--dsh-odoo.json` is touched; no README, workflow, or script changes.
- Both descriptions are factual and describe only behaviour that the code implements.