### PR TITLE
catalog: add Adamaik/dsh-git-sidebar

### DIFF
--- a/catalog/plugins/adamaik--dsh-git-sidebar.json
+++ b/catalog/plugins/adamaik--dsh-git-sidebar.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Adamaik/dsh-git-sidebar",
+  "name": "dsh-git-sidebar",
+  "repository": "https://github.com/Adamaik/dsh-git-sidebar",
+  "category": "ui",
+  "description": {
+    "en": "A draggable right-side Git sidebar for DeepSeek Harness Web: follows the active workspace, lists changed files, generates commit messages with the current model, and runs commit/push/pull.",
+    "zh": "面向 DeepSeek Harness Web 的可拖拽右侧 Git 侧栏：跟随当前工作区、列出变更文件、用当前模型生成提交信息，并支持提交/推送/拉取。"
+  },
+  "added": "2026-08-27"
+}


### PR DESCRIPTION
## 摘要

将 [`Adamaik/dsh-git-sidebar`](https://github.com/Adamaik/dsh-git-sidebar) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`node --check lib/index.js && node --check lib/client.js`；在 desktop profile 中通过 `dsh plugin --profile desktop add file:/tmp/dsh-git-sidebar-0.1.0.tgz` 安装，`dsh --profile desktop --dump-config` 确认 `git-sidebar` 行正确组合；随后以模拟 webServer/shell 服务加载 host 半，确认 8 条 `/git-sidebar/*` 路由全部注册，并对真实 git 仓库执行 `/git-sidebar/status` 返回正确分支与变更列表。
- 测试结果：全部通过 —— 插件已在测试期间作为动态插件在 DeepSeek Harness Web 中实际使用（状态、暂存、提交、推送、拉取、分支切换、AI 生成提交信息均可工作），随后固化为本仓库的持久化 bundle 并验证加载。

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
