### PR TITLE
Update internal-skill-workshop description

### DIFF
--- a/catalog/plugins/olina1ye--internal-skill-workshop-plugin.json
+++ b/catalog/plugins/olina1ye--internal-skill-workshop-plugin.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/Olina1Ye/internal-skill-workshop-plugin",
   "category": "skill",
   "description": {
-    "en": "Adds an Internal Skill Workshop panel to DeepSeek Harness for browsing skills from a configured Skill Base server.",
-    "zh": "在 DeepSeek Harness 中增加 Internal Skill Workshop 面板，用于浏览配置的 Skill Base 服务中的 Skill。"
+    "en": "Browses, signs in to, and safely installs public or private team Skills from a configured Skill Base in DSH Web.",
+    "zh": "在 DSH Web 中浏览、登录并安全安装来自团队 Skill Base 的公开或私有 Skill。"
   },
   "added": "2026-08-27"
 }


### PR DESCRIPTION
## Summary

Update the existing catalog description for `internal-skill-workshop` to match the published `0.2.0` feature set.

The plugin now supports:

- public and private team Skill browsing
- verification-code sign-in
- safe installation from a configured Skill Base

This PR changes only the plugin's existing catalog JSON entry.

- Repository: https://github.com/Olina1Ye/internal-skill-workshop-plugin
- npm: https://www.npmjs.com/package/internal-skill-workshop