### PR TITLE
Add Sutera-Diffusus/dsh-whale-musume

### DIFF
--- a/catalog/plugins/sutera-diffusus--dsh-whale-musume.json
+++ b/catalog/plugins/sutera-diffusus--dsh-whale-musume.json
@@ -1,0 +1,12 @@
+{
+    "$schema":  "../schema/plugin.schema.json",
+    "id":  "Sutera-Diffusus/dsh-whale-musume",
+    "name":  "dsh-whale-musume",
+    "repository":  "https://github.com/Sutera-Diffusus/dsh-whale-musume",
+    "category":  "fun",
+    "description":  {
+                        "en":  "Whale-girl desktop pet for the DSH web UI: pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements, drag physics, theme sync and a built-in settings panel; local-first, zero telemetry (MIT, 102 unit tests).",
+                        "zh":  "DSH Web 的元气鲸鱼娘桌宠：摸头养成、工作状态联动、494 条台词与 30 项成就，支持拖拽物理、主题适配与内置设置面板；全本地、零遥测（MIT，102 项单测）。"
+                    },
+    "added":  "2026-08-28"
+}


### PR DESCRIPTION
Add [Sutera-Diffusus/dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) to catalog/plugins/. Whale-girl desktop pet for the DSH web UI (pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements, built-in settings panel; local-first, zero telemetry; MIT; 102 unit tests). Repo has the dsh-plugin topic and declares dsh.bundle.patch.