### PR TITLE
catalog: add stas130286-blip/dsh-brainagent

### DIFF
--- a/catalog/plugins/stas130286-blip--dsh-brainagent.json
+++ b/catalog/plugins/stas130286-blip--dsh-brainagent.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "stas130286-blip/dsh-brainagent",
+  "name": "dsh-brainagent",
+  "repository": "https://github.com/stas130286-blip/dsh-brainagent",
+  "category": "memory",
+  "description": {
+    "en": "Brain-inspired cognitive plugin: episodic, semantic, procedural and emotional memory with reinforcement-learning signals, a goal stack with time triggers, curiosity-driven autonomous web research, and proactive initiatives.",
+    "zh": "受大脑启发的认知插件:情景、语义、程序与情绪记忆,带强化学习信号;目标栈支持时间触发器,好奇心驱动的自主网络研究,以及主动提议。"
+  },
+  "added": "2026-08-28"
+}


### PR DESCRIPTION
## Plugin

Repository: https://github.com/stas130286-blip/dsh-brainagent

dsh-brainagent is a brain-inspired cognitive plugin for DeepSeek Harness. It adds persistent episodic, semantic, procedural and emotional memory with reinforcement-learning signals, a goal stack with time triggers and reminders, curiosity-driven autonomous web research, and proactive initiatives passing an activation filter. The plugin ships as a prebuilt bundle with a committed cordis host patch (dsh.bundle.patch = ./cordis.patch.yml) and /brain commands for status, memory and goals inspection.

## Author verification

Commands run by the author on commit aaf8d9d of the plugin repository:

- `npm install --legacy-peer-deps` then `npx vitest run` — 915/915 tests pass (64 files)
- `npx tsc --noEmit` — clean
- `npm run build` (esbuild) — bundle rebuilt; `git diff --exit-code lib/index.js` — no drift
- GitHub Actions CI green on aaf8d9d: install, typecheck, tests, build, bundle-drift check, UTF-8 encoding check
- Live host: installed into a running dsh web profile via `npx @deepseek-ai/dsh plugin add github:stas130286-blip/dsh-brainagent`; in production since v0.9.7, current live version 0.9.27 (metrics.json sections.version), errors {}
- L3 security review — 0 findings

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically