### PR TITLE
Add dsh-git plugin

### DIFF
--- a/catalog/plugins/ayumedaze--dsh-git.json
+++ b/catalog/plugins/ayumedaze--dsh-git.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ayumedaze/dsh-git",
+  "name": "dsh-git",
+  "repository": "https://github.com/ayumedaze/dsh-git",
+  "category": "dev",
+  "description": {
+    "en": "Fork-style Git GUI embedded in DeepSeek Harness: multi-select stage/unstage, diff viewer, commit, branches, stashes, clone and SSH key setup, and a workspace switcher.",
+    "zh": "内嵌于 DeepSeek Harness 的 Fork 风格 Git 图形界面：多选暂存/取消暂存、diff 查看、提交、分支、stash、克隆与 SSH 密钥配置，以及工作区切换。"
+  },
+  "added": "2026-08-29"
+}


### PR DESCRIPTION
## Plugin

Adds [dsh-git](https://github.com/ayumedaze/dsh-git) - a Fork-style Git GUI embedded in DeepSeek Harness Web: multi-select stage/unstage, diff viewer, commit, branches, stashes, clone, SSH key setup, and a workspace switcher.

## Author verification

Tested locally in DeepSeek Harness Desktop: opened the Git panel, staged/unstaged files (single and multi-select), viewed diffs, committed, and opened the Console terminal at the active repo. Host/client modules pass 
ode --check.

## Catalog submissions

- [x] This PR only touches catalog/plugins/*.json files
- [x] New plugin: this PR adds exactly one catalog/plugins/*.json file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares dsh.bundle.patch and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] dsh-plugin topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically