### PR TITLE
catalog: add dsh-product-subagent-console

### DIFF
--- a/catalog/plugins/jokasa7--dsh-product-subagent-console.json
+++ b/catalog/plugins/jokasa7--dsh-product-subagent-console.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Jokasa7/dsh-product-subagent-console",
+  "name": "dsh-product-subagent-console",
+  "repository": "https://github.com/Jokasa7/dsh-product-subagent-console",
+  "category": "workflow",
+  "description": {
+    "en": "Design editable multi-Agent task plans, observe real child sessions, compare planned work with actual attempts, and preview evidence-backed recovery inside DSH conversations.",
+    "zh": "在 DSH 对话中设计可编辑的多 Agent 任务计划、观察真实子会话、对照计划与实际执行，并预览基于证据的恢复方案。"
+  },
+  "added": "2026-08-29"
+}


### PR DESCRIPTION
## Summary

Add `Jokasa7/dsh-product-subagent-console` as one `workflow` catalog entry.

The plugin provides editable multi-Agent task planning, observation of real child sessions, plan-versus-runtime comparison, and evidence-backed recovery previews inside DSH conversations.

## Verification

- Public repository: https://github.com/Jokasa7/dsh-product-subagent-console
- Root `package.json` declares `dsh.bundle.patch` through `dsh.bundle`
- Referenced `cordis.patch.yml` is committed
- Repository has the `dsh-plugin` topic
- Tested release: v0.9.0 with DSH 0.1.1-rc.2
- The npm package is not published yet; this submission is intentionally browse-only, as allowed by the catalog rules

Only `catalog/plugins/jokasa7--dsh-product-subagent-console.json` is added.