### PR TITLE
Add dsh-clawtouch

### DIFF
--- a/catalog/plugins/tinqiao-oss--clawtouch-mcp--adapters--dsh--plugin.json
+++ b/catalog/plugins/tinqiao-oss--clawtouch-mcp--adapters--dsh--plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "tinqiao-oss/clawtouch-mcp/adapters/dsh/plugin",
+  "name": "dsh-clawtouch",
+  "repository": "https://github.com/tinqiao-oss/clawtouch-mcp",
+  "category": "tools",
+  "description": {
+    "en": "Computer use through an external USB HID device: name a target in plain language, a vision model locates it in a cropped window screenshot, and a Raspberry Pi Pico 2 moves the real mouse and types on the real keyboard. 7 tools. Windows has window listing, per-window cropping and automatic window raising; macOS needs pyobjc and has neither; Linux is unsupported.",
+    "zh": "通过外接 USB HID 硬件做电脑控制：用一句话描述目标，视觉模型在裁剪后的窗口截图里定位，树莓派 Pico 2 驱动真实鼠标和键盘完成动作。7 个工具。Windows 支持窗口枚举、按窗口裁剪与自动抬窗；macOS 需 pyobjc 且不支持这两项；Linux 不支持。"
+  },
+  "added": "2026-08-29"
+}


### PR DESCRIPTION
Adds `dsh-clawtouch`, a monorepo subpackage entry: `tinqiao-oss/clawtouch-mcp/adapters/dsh/plugin`.

**What it does.** The agent names a target in plain language — `computer_click({ target: "the blue Send button at the bottom right" })`. The plugin screenshots the target window cropped to that window, a vision model returns coordinates, and a Raspberry Pi Pico 2 moves the real mouse and presses the real key over USB HID. The agent never sees the screenshot and never computes a coordinate.

**7 tools:** `computer_click`, `computer_click_sequence`, `computer_find`, `computer_windows`, `computer_type`, `computer_key`, `computer_scroll`.

**Platform support is uneven, and the description says so:** window listing, per-window cropping and automatic window raising are Windows-only; macOS needs pyobjc and has neither; Linux is unsupported.

Checklist:

- `adapters/dsh/plugin/package.json` declares `dsh.bundle.patch` → `cordis.patch.yml`, and that file is committed
- published to npm as [`dsh-clawtouch`](https://www.npmjs.com/package/dsh-clawtouch) — MIT, no runtime dependencies
- `dsh-plugin` topic added to the repository
- `validateCatalogEntry` passes locally against this entry
- one new file under `catalog/plugins/`, nothing else touched
