### PR TITLE
Add dsh-engramory

### DIFF
--- a/catalog/plugins/tinqiao-oss--engramory--adapters--dsh--plugin.json
+++ b/catalog/plugins/tinqiao-oss--engramory--adapters--dsh--plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "tinqiao-oss/engramory/adapters/dsh/plugin",
+  "name": "dsh-engramory",
+  "repository": "https://github.com/tinqiao-oss/engramory",
+  "category": "memory",
+  "description": {
+    "en": "Long-term memory for DeepSeek Harness kept as plain markdown, one fact per file, readable in any editor. The `MEMORY.md` index has a hard 200-line / 25 KB cap enforced by `ctx.tools.guard()`: a write that would grow an over-cap index is denied, while a rewrite that shrinks it always passes, so an oversized index can be compacted step by step. The plugin never writes memories on its own — what is kept is decided by you and the model. The same store is also used by Claude Code, Codex, Kiro and OpenClaw.",
+    "zh": "给 DeepSeek Harness 的长期记忆，以纯 markdown 保存：一条事实一个文件，任何编辑器都能打开。索引 `MEMORY.md` 有 200 行 / 25KB 的硬上限，由 `ctx.tools.guard()` 强制执行——让已超限的索引继续变大的写入会被拒绝，而缩小它的重写一律放行，于是过大的索引可以一步步压缩下来。插件不会自行写入记忆，记什么由你和模型决定。同一个记忆库也被 Claude Code、Codex、Kiro、OpenClaw 使用。"
+  },
+  "added": "2026-08-29"
+}


### PR DESCRIPTION
Adds `dsh-engramory`, a monorepo subpackage entry: `tinqiao-oss/engramory/adapters/dsh/plugin`.

Curated file-based long-term memory for DeepSeek Harness: one fact per plain markdown file, readable in any editor, with a `MEMORY.md` index capped at 200 lines / 25 KB by `ctx.tools.guard()` — a write that would grow an already-over-cap index is denied, while a rewrite that shrinks it always passes, so an oversized index can be compacted step by step. The plugin never writes memories on its own; what is kept is decided by the user and the model. The same store is shared with Claude Code, Codex, Kiro and OpenClaw.

Checklist:

- `adapters/dsh/plugin/package.json` declares `dsh.bundle.patch` → `cordis.patch.yml`, and that file is committed
- published to npm as [`dsh-engramory`](https://www.npmjs.com/package/dsh-engramory) v0.2.3 — MIT
- `dsh-plugin` topic already on the repository
- `validateCatalogEntry` passes locally against this entry
- one new file under `catalog/plugins/`, nothing else touched
