### PR TITLE
Add mhwww/DSH-Wallpaper-Engine

### DIFF
--- a/catalog/plugins/mhwww--dsh-wallpaper-engine.json
+++ b/catalog/plugins/mhwww--dsh-wallpaper-engine.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "mhwww/DSH-Wallpaper-Engine",
+  "name": "DSH-Wallpaper-Engine",
+  "repository": "https://github.com/mhwww/DSH-Wallpaper-Engine",
+  "category": "theme",
+  "description": {
+    "en": "Applies local Wallpaper Engine workshop wallpapers as the DeepSeek Harness web background from a settings card. Per-type HD pipeline: scene wallpapers unpack scene.pkg via RePKG for native textures, video wallpapers extract native-resolution frames via ffmpeg, scene/web previews fetch the author's original from the Steam CDN; includes playlist pinning, gallery hide/restore and a dim-layer opacity control. RePKG and ffmpeg are optional and fall back to lower-quality previews.",
+    "zh": "在设置卡片中把本机 Wallpaper Engine 创意工坊壁纸设为 DSH Web 背景。按类型走高清链：scene 壁纸经 RePKG 解包 scene.pkg 取原生贴图，视频壁纸用 ffmpeg 抽原生分辨率帧，scene/web 预览取 Steam CDN 作者原图；支持播放列表置顶、画廊隐藏/恢复与遮罩不透明度调节。RePKG 与 ffmpeg 为可选依赖，缺失时回退低清预览。"
+  },
+  "added": "2026-08-30"
+}


### PR DESCRIPTION
## Add a plugin

Adds `catalog/plugins/mhwww--dsh-wallpaper-engine.json`.

- **Repository**: https://github.com/mhwww/DSH-Wallpaper-Engine
- **Category**: theme
- **package.json**: declares `dsh.bundle.patch` (`./cordis.patch.yml`, committed at repo root) — verified in the default branch
- **GitHub topics**: `dsh-plugin`, `deepseek-harness`, `dsh-background`, `wallpaper-engine`, `electron-free`

### Plugin summary

Applies local Wallpaper Engine workshop wallpapers as the DeepSeek Harness web background from a settings card. Per-type HD pipeline: scene wallpapers unpack `scene.pkg` via RePKG for native textures, video wallpapers extract native-resolution frames via ffmpeg, scene/web previews fetch the author's original from the Steam CDN; includes playlist pinning, gallery hide/restore and dim-layer opacity control. RePKG and ffmpeg are optional and fall back to lower-quality previews.

### Checklist

- [x] `package.json` declares non-empty `dsh.bundle.patch` and the patch file is committed
- [x] `dsh-plugin` GitHub topic added
- [x] Plugin tested locally (installed via `dsh plugin --profile web add`, running on dsh 0.1.1-rc.2)
- [x] Entry file named per convention (`mhwww--dsh-wallpaper-engine.json`), category `theme`
- [x] Descriptions factual and neutral; no npm package published yet (expected browse-only listing)