### PR TITLE
Add DSH Vibeify experience

### DIFF
--- a/catalog/plugins/n9-developer-empowerment--dsh-vibeify--plugins--dsh-vibeify-experience.json
+++ b/catalog/plugins/n9-developer-empowerment--dsh-vibeify--plugins--dsh-vibeify-experience.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "N9-Developer-Empowerment/DSH-Vibeify/plugins/dsh-vibeify-experience",
+  "name": "dsh-vibeify-experience",
+  "repository": "https://github.com/N9-Developer-Empowerment/DSH-Vibeify",
+  "category": "ui",
+  "description": {
+    "en": "Turns completed DeepSeek Harness public-content work into a browser-local visual magazine with explicit updates and reviewed one-article sharing.",
+    "zh": "将 DeepSeek Harness 中已完成的公开内容工作整理为浏览器本地的视觉杂志，支持显式更新和经审核的单篇文章分享。"
+  },
+  "added": "2026-08-29"
+}


### PR DESCRIPTION
Adds the provider-neutral DSH Vibeify experience as one catalogue entry.

- Manifest: `plugins/dsh-vibeify-experience/package.json`
- Bundle patch: `plugins/dsh-vibeify-experience/cordis.patch.yml`
- Category: UI
- Source release: Vibeify 0.15.2

The package is not currently published to npm, so this submission intentionally accepts the catalogue's browse-only status.
