### PR TITLE
catalog: add amazon-sucareer

### DIFF
--- a/catalog/plugins/soberbiak--amazon-sucareer.json
+++ b/catalog/plugins/soberbiak--amazon-sucareer.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../schema/plugin.schema.json",
   "id": "soberbiak/amazon-sucareer",
   "name": "amazon-sucareer",
   "repository": "https://github.com/soberbiak/amazon-sucareer",

--- a/catalog/plugins/soberbiak--amazon-sucareer.json
+++ b/catalog/plugins/soberbiak--amazon-sucareer.json
@@ -1,0 +1,11 @@
+{
+  "id": "soberbiak/amazon-sucareer",
+  "name": "amazon-sucareer",
+  "repository": "https://github.com/soberbiak/amazon-sucareer",
+  "category": "skill",
+  "description": {
+    "en": "Evidence-first Amazon marketplace operations career skill bundle for turning raw work material into a claim ledger, role positioning, resumes, interview practice, and recruiter greetings.",
+    "zh": "面向亚马逊运营求职的证据优先 Skill 套件：将工作素材整理为可核验的证据账本、岗位定位、简历、面试练习和招聘沟通内容。"
+  },
+  "added": "2026-08-30"
+}


### PR DESCRIPTION
## Plugin

Repository: https://github.com/soberbiak/amazon-sucareer

Evidence-first Amazon marketplace operations career Skill bundle. It turns raw work material into a claim ledger, role positioning, resumes, interview practice, and recruiter greetings.

## Author verification

Tested locally:

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 12 tests passed.
- `npm pack --dry-run --json --cache /private/tmp/amazon-sucareer-npm-cache` — package contents validated.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that the catalog will refresh automatically after merge