### PR TITLE
catalog: add dsh-gacha-calendar

### DIFF
--- a/catalog/plugins/eastmg--dsh-gacha-calendar.json
+++ b/catalog/plugins/eastmg--dsh-gacha-calendar.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "EastMG/dsh-gacha-calendar",
+  "name": "dsh-gacha-calendar",
+  "repository": "https://github.com/EastMG/dsh-gacha-calendar",
+  "category": "ui",
+  "description": {
+    "en": "Anime game banner and event schedule lookup: a sidebar button shows current banners and events with countdowns for 10 gacha games, with auto-refresh and per-game selectable sources.",
+    "zh": "二游卡池/活动排期速查：侧边栏按钮展示 10 款二游的当期卡池与活动起止（含倒计时），支持自动刷新与各游戏独立来源切换。"
+  },
+  "added": "2026-08-30"
+}


### PR DESCRIPTION
Adds [dsh-gacha-calendar](https://github.com/EastMG/dsh-gacha-calendar) — anime game banner/event schedule sidebar plugin for DeepSeek Harness.

- package.json declares \dsh.bundle.patch\ (cordis.patch.yml) and \dsh.client\ inject
- repo carries the \dsh-plugin\ topic
- category: ui