### PR TITLE
Add warment/deepseek-harness-locale-ru

### DIFF
--- a/catalog/plugins/warment--deepseek-harness-locale-ru.json
+++ b/catalog/plugins/warment--deepseek-harness-locale-ru.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "warment/deepseek-harness-locale-ru",
+  "name": "deepseek-harness-locale-ru",
+  "repository": "https://github.com/warment/deepseek-harness-locale-ru",
+  "category": "ui",
+  "description": {
+    "en": "Russian (Русский) language pack for the DSH Web UI: 33 namespaces, 1061 strings (100% coverage) registered through the official dsh-client-locale plugin API; also localizes permission preset display names via a config layer.",
+    "zh": "DSH 网页界面的俄语语言包：通过官方 dsh-client-locale 插件 API 注册 33 个命名空间、1061 条界面字符串（100% 覆盖）；并通过配置层本地化权限预设显示名。"
+  },
+  "added": "2026-08-30"
+}


### PR DESCRIPTION
Adds one new catalog entry: `catalog/plugins/warment--deepseek-harness-locale-ru.json`.

- Russian (Русский) locale pack for the DSH Web UI via the official `dsh-client-locale` plugin API — 33 namespaces / 1061 strings (100% coverage), CI drift-check against upstream (`check.mjs --strict`)
- Repo: https://github.com/warment/deepseek-harness-locale-ru · MIT · carries the `dsh-plugin` topic
- No npm package yet — repository-link listing for now; will publish to npm later, the store should then pick up the install command automatically.