### PR TITLE
Update dsh-session-nav catalog entry: DSH 0.1.2+ compatibility

### DIFF
--- a/catalog/plugins/kiligzzz--dsh-session-nav.json
+++ b/catalog/plugins/kiligzzz--dsh-session-nav.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/kiligzzz/dsh-session-nav",
   "category": "session",
   "description": {
-    "en": "Piano-key style in-conversation navigation bar: one key per real user message of the current session. Hover a key to preview that turn, click to jump smoothly; auto-pages older history when the target is outside the virtualized window.",
-    "zh": "钢琴键风格的会话内导航条：每根键对应当前会话的一个真实用户问题（数据来自完整磁盘日志）。悬停键预览该轮「用户消息 + 模型回复」，点击平滑跳转到对应位置；当目标在虚拟列表窗口外时，自动翻页加载更早的历史，无需手动操作。"
+    "en": "Piano-key style in-conversation navigation bar: one key per real user message of the current session. Hover a key to preview that turn (user message + model reply, extracted from the full on-disk log), click to jump smoothly; auto-pages older history when the target is outside the virtualized window. Compatible with DSH 0.1.2+ (uses the official uiConversation chat snapshot).",
+    "zh": "钢琴键风格的会话内导航条：每根键对应当前会话的一个真实用户问题（数据来自完整磁盘日志）。悬停键预览该轮「用户消息 + 模型回复」（历史回复从磁盘日志提取），点击平滑跳转到对应位置；当目标在虚拟列表窗口外时，自动翻页加载更早的历史，无需手动操作。适配 DSH 0.1.2+（使用官方 uiConversation chat 快照）。"
   },
   "added": "2026-08-20"
 }


### PR DESCRIPTION
Update the existing [kiligzzz/dsh-session-nav](https://github.com/kiligzzz/dsh-session-nav) catalog entry:

- Note DSH 0.1.2+ compatibility (uses official `uiConversation` chat snapshot after the 0.1.2 snapshot rework)
- Mention full-history reply preview (historical replies extracted from the on-disk log)
- Single `catalog/plugins/*.json` file changed, schema-valid