### PR TITLE
catalog: add bosinHU/dsh-skill-editor

### DIFF
--- a/catalog/plugins/bosinhu--dsh-skill-editor.json
+++ b/catalog/plugins/bosinhu--dsh-skill-editor.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "bosinHU/dsh-skill-editor",
+  "name": "dsh-skill-editor",
+  "repository": "https://github.com/bosinHU/dsh-skill-editor",
+  "category": "skill",
+  "description": {
+    "en": "Settings-page skill editor for the DeepSeek Harness web UI: edit a skill's SKILL.md body and frontmatter description in place. Local skills (in ~/.dsh/skills, ~/.agents/skills, or the workspace .dsh/skills) are freely editable; bundled/built-in skills are read-only with a warning. Saving writes the SKILL.md to disk immediately and skills are hot-loaded without restarting dsh.",
+    "zh": "在 dsh Web 设置页直接编辑技能 SKILL.md 的正文与 frontmatter 描述：本地技能（~/.dsh/skills、~/.agents/skills、工作区 .dsh/skills）可自由编辑保存，系统/内置技能只读并给出风险提示；保存后立即写盘，技能热加载、无需重启 dsh。"
+  },
+  "added": "2026-08-30"
+}


### PR DESCRIPTION

## 插件
- ID: `bosinHU/dsh-skill-editor`
- 分类: `skill`
- 仓库: https://github.com/bosinHU/dsh-skill-editor（公开，MIT，含 `dsh-plugin` topic）
- 功能: dsh Web 设置页内直接编辑技能 SKILL.md 正文与 frontmatter 描述；本地技能可保存写盘，bundled 技能只读并提示风险

## 作者实测
- `dsh plugin --profile web add ./dsh-skill-editor` 安装至 web profile，重启后设置页出现「技能编辑器」分栏
- 本地技能编辑保存后立即写盘，刷新即可生效（技能热加载）
- typert 协议已按新版要求自检：host 端 MANIFEST 所有参数带 codec，client 端所有 field 使用 strict codec

## 目录提交
- 仅新增 `catalog/plugins/bosinhu--dsh-skill-editor.json` 一个文件
- 允许维护者修改：已勾选（请保持勾选）