### PR TITLE
Add Idreamxkl/dsh-conversation-flat

### DIFF
--- a/catalog/plugins/idreamxkl--dsh-conversation-flat.json
+++ b/catalog/plugins/idreamxkl--dsh-conversation-flat.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Idreamxkl/dsh-conversation-flat",
+  "name": "dsh-conversation-flat",
+  "repository": "https://github.com/Idreamxkl/dsh-conversation-flat",
+  "category": "ui",
+  "description": {
+    "en": "Conversation UI adjustments for the DeepSeek Harness web GUI: document-flow layout with full-width column, user message bars, and full-width tables; a conversation minimap with hover previews and click-to-jump; and a personal profile (circular avatar and display name) configured from a settings section, persisted to the host's settings.yaml.",
+    "zh": "对话区 UI 调整：通栏文档式布局（全宽正文列、用户消息条、通栏表格），带悬停预览与点击跳转的会话小地图，以及个人资料功能（圆形头像与显示名称），在设置面板的「个人资料」分区配置，经 settingsScope 持久化到宿主 settings.yaml。"
+  },
+  "added": "2026-08-31"
+}


### PR DESCRIPTION
Adds a new catalog entry for [dsh-conversation-flat](https://github.com/Idreamxkl/dsh-conversation-flat), a UI plugin for the DeepSeek Harness web GUI.

- `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml`, and the patch file exists in the same tree (tag v0.3.3).
- The repository is public and carries the `dsh-plugin` topic (already auto-discovered by the collector, see [deepseek1024.com entry](https://deepseek1024.com/plugin/Idreamxkl/dsh-conversation-flat)).
- No npm package yet, so the entry is expected to be browse-only until one is published.

Single new file under `catalog/plugins/` only.