### PR TITLE
catalog: add dsh-composer-layout

### DIFF
--- a/catalog/plugins/lavapapa--dsh-composer-layout.json
+++ b/catalog/plugins/lavapapa--dsh-composer-layout.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "lavapapa/dsh-composer-layout",
+  "name": "dsh-composer-layout",
+  "repository": "https://github.com/lavapapa/dsh-composer-layout",
+  "category": "ui",
+  "description": {
+    "en": "A DSH Web plugin that keeps long answers and detailed prompts side by side with a dockable Composer.",
+    "zh": "让长回答与详细提示词通过可停靠的 Composer 并排显示的 DSH Web 插件。"
+  },
+  "added": "2026-08-31"
+}


### PR DESCRIPTION
## Summary

Add the published `dsh-composer-layout` DSH Web plugin to the UI catalog.

- Repository: https://github.com/lavapapa/dsh-composer-layout
- npm package: https://www.npmjs.com/package/dsh-composer-layout
- The package declares `dsh.bundle.patch` and ships prebuilt host/client artifacts.

## Scope

This pull request adds exactly one catalog entry and changes no generated files, workflows, or scripts.