### PR TITLE
Add LAU-MARS/dsh-cad

### DIFF
--- a/catalog/plugins/lau-mars--dsh-cad.json
+++ b/catalog/plugins/lau-mars--dsh-cad.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "LAU-MARS/dsh-cad",
+  "name": "dsh-cad",
+  "repository": "https://github.com/LAU-MARS/dsh-cad",
+  "category": "tools",
+  "description": {
+    "en": "Views and builds CAD models (STL, OBJ, STEP, IGES, DXF, SVG) via cad_view/cad_info and OCCT parametric modeling tools, with an interactive viewer card and a resident CAD panel in the Web UI.",
+    "zh": "通过 cad_view/cad_info 与 OCCT 参数化建模工具查看和构建 CAD 模型（STL、OBJ、STEP、IGES、DXF、SVG），并在 Web UI 中提供交互式查看卡片与常驻 CAD 面板。"
+  },
+  "added": "2026-08-31"
+}


### PR DESCRIPTION
Adds catalog/plugins/lau-mars--dsh-cad.json — CAD viewer + OCCT parametric modeling plugin for DeepSeek Harness. Repo declares a non-empty dsh.bundle.patch (./cordis.patch.yml, committed) and carries the dsh-plugin topic. Not yet on npm, so it will be listed browse-only until published.