### PR TITLE
Add KongFangXun/sofagent to catalog

### DIFF
--- a/catalog/plugins/kongfangxun--sofagent.json
+++ b/catalog/plugins/kongfangxun--sofagent.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "KongFangXun/sofagent",
+  "name": "sofagent",
+  "repository": "https://github.com/KongFangXun/sofagent",
+  "category": "dev",
+  "description": {
+    "en": "Commit-time governance harness for AI coding agents: 24 deterministic audit rules over git diffs (secrets, out-of-scope edits, blind modifications, prompt-injection traces), HMAC-chained audit history, and a 9-plugin DSH family under engine/dsh-plugins.",
+    "zh": "面向 AI 编程 Agent 的提交时治理 harness：24 条确定性规则审查 git diff（密钥、越权改动、盲改、提示注入痕迹），HMAC 链式防篡改审计记录，engine/dsh-plugins 下附 9 插件 DSH 家族。"
+  },
+  "added": "2026-09-01"
+}


### PR DESCRIPTION
Adds exactly one new catalog entry: `catalog/plugins/kongfangxun--sofagent.json` (repository-level id `KongFangXun/sofagent`, category `dev`). No other paths touched.

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

sofagent is a commit-time governance harness for AI coding agents: 24 deterministic audit rules over git diffs, HMAC-chained audit history, and a 9-plugin DSH plugin family. Each plugin under `engine/dsh-plugins/cordis-plugin-sofagent-*` has its own `package.json` declaring `dsh.bundle.patch` with the patch file committed in the same tree — the static gate can verify via the GitHub API.

- The repo carries the `dsh-plugin` GitHub topic for tokenless discovery.
- Plugins are distributed via SkillHub (`skillhub install cordis-plugin-sofagent-*`); not npm-published, so browse-only listing is expected and fine.

Related: [0xsline/awesome-deepseek-harness #547](https://github.com/0xsline/awesome-deepseek-harness/pull/547), [Anil-matcha/awesome-dsh-plugin #122](https://github.com/Anil-matcha/awesome-dsh-plugin/pull/122), [Dominic789654/awesome-deepseek-harness PR](https://github.com/Dominic789654/awesome-deepseek-harness/pulls) (submitted today).
