### PR TITLE
catalog: add l2685209197/dsh-pdf-translate

### DIFF
--- a/catalog/plugins/l2685209197--dsh-pdf-translate.json
+++ b/catalog/plugins/l2685209197--dsh-pdf-translate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "l2685209197/dsh-pdf-translate",
+  "name": "dsh-pdf-translate",
+  "repository": "https://github.com/l2685209197/dsh-pdf-translate",
+  "category": "tools",
+  "description": {
+    "en": "Translate text-based PDFs with DeepSeek or OpenAI-compatible APIs, preserving layout, fonts, images and links; editable output, ≤50 pages per task.",
+    "zh": "用 DeepSeek 或兼容 API 翻译文本型 PDF，保留版式、字体、图片与链接，输出可编辑 PDF（单次 ≤50 页）。"
+  },
+  "added": "2026-09-01"
+}


### PR DESCRIPTION
## 摘要

将 [`l2685209197/dsh-pdf-translate`](https://github.com/l2685209197/dsh-pdf-translate) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`python -m pytest worker/tests -q && pnpm exec vitest run && pnpm exec tsc -p tsconfig.json --noEmit`
- 测试结果：`41 Python + 73 TS 全部通过；tsc exit 0`

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
