### PR TITLE
Add archived-conversations management plugin

### DIFF
--- a/catalog/plugins/leogottadothebest--dsh-archived-delete.json
+++ b/catalog/plugins/leogottadothebest--dsh-archived-delete.json
@@ -1,7 +1,12 @@
-Add the archived-conversations management plugin for DeepSeek Harness.
-
-- npm (published, installable from the store): dsh-plugin-archived-conversations@0.1.1
-- Declares `dsh.bundle.patch` (`./cordis.patch.yml`) in package.json
-- GitHub topic `dsh-plugin` already added
-- Category `session`: unarchive and permanently delete archived conversations from the Settings UI
-- Single new catalog/plugins entry; nothing outside catalog/plugins/ touched
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "leogottadothebest/DSH-Archived-Delete",
+  "name": "dsh-plugin-archived-conversations",
+  "repository": "https://github.com/leogottadothebest/DSH-Archived-Delete",
+  "category": "session",
+  "description": {
+    "en": "Manage archived conversations in the Settings UI: unarchive them back to the sidebar, or permanently delete them with confirmation.",
+    "zh": "在设置界面管理已归档对话：一键取消归档，或经确认后永久删除。"
+  },
+  "added": "2026-09-02"
+}

--- a/catalog/plugins/leogottadothebest--dsh-archived-delete.json
+++ b/catalog/plugins/leogottadothebest--dsh-archived-delete.json
@@ -1,0 +1,7 @@
+Add the archived-conversations management plugin for DeepSeek Harness.
+
+- npm (published, installable from the store): dsh-plugin-archived-conversations@0.1.1
+- Declares `dsh.bundle.patch` (`./cordis.patch.yml`) in package.json
+- GitHub topic `dsh-plugin` already added
+- Category `session`: unarchive and permanently delete archived conversations from the Settings UI
+- Single new catalog/plugins entry; nothing outside catalog/plugins/ touched


### PR DESCRIPTION
Add the archived-conversations management plugin for DeepSeek Harness, allowing unarchiving and permanent deletion of archived conversations.

## Plugin

Link the submitted plugin repository and summarize its user-visible capability.

## Author verification

List the real command and result used to test plugin behavior and compatibility. The catalog workflow does not execute third-party plugin code.

## Catalog submissions

- [ ] This PR only touches `catalog/plugins/*.json` files
- [ ] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [ ] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [ ] Plugin behavior and compatibility were tested by the author
- [ ] `dsh-plugin` topic added
- [ ] English and Chinese descriptions are neutral and accurate
- [ ] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically
