### PR TITLE
Update entry for leogottadothebest: repo renamed to dsh-plugin-archived-conversations

### DIFF
--- a/catalog/plugins/leogottadothebest--dsh-plugin-archived-conversations.json
+++ b/catalog/plugins/leogottadothebest--dsh-plugin-archived-conversations.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../schema/plugin.schema.json",
-  "id": "leogottadothebest/DSH-Archived-Delete",
+  "id": "leogottadothebest/dsh-plugin-archived-conversations",
   "name": "dsh-plugin-archived-conversations",
-  "repository": "https://github.com/leogottadothebest/DSH-Archived-Delete",
+  "repository": "https://github.com/leogottadothebest/dsh-plugin-archived-conversations",
   "category": "session",
   "description": {
     "en": "Manage archived conversations in the Settings UI: unarchive them back to the sidebar, or permanently delete them with confirmation.",


### PR DESCRIPTION
This PR updates the existing catalog entry for the archived-conversations management plugin (originally added in #311) after its repository was renamed from `DSH-Archived-Delete` to `dsh-plugin-archived-conversations`.

Changes (one existing entry only):
- Rename `catalog/plugins/leogottadothebest--dsh-archived-delete.json` → `catalog/plugins/leogottadothebest--dsh-plugin-archived-conversations.json` (filename is the slugged plugin id)
- Update `id` and `repository` to the renamed repository (`name` was already the new package name)

The old URL 301-redirects to the renamed repository. As an existing-entry update this PR is expected to require maintainer review.