### PR TITLE
catalog: add tianxia--/dsh-llm-local-token

### DIFF
--- a/catalog/plugins/tianxia--dsh-llm-local-token.json
+++ b/catalog/plugins/tianxia--dsh-llm-local-token.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "tianxia--/dsh-llm-local-token",
+  "name": "dsh-llm-local-token",
+  "repository": "https://github.com/tianxia--/dsh-llm-local-token",
+  "category": "model",
+  "description": {
+    "en": "Registers `openai-codex` and `anthropic` LLM routes from the OAuth credentials the local Codex CLI and Claude Code already hold, refreshing the token near expiry and showing each subscription's remaining quota in a web panel.",
+    "zh": "复用本机 Codex CLI 与 Claude Code 已持有的 OAuth 凭据注册 `openai-codex` 与 `anthropic` LLM 路由，在临近过期时刷新 token，并在 Web 面板中显示各订阅的剩余额度。"
+  },
+  "added": "2026-09-02"
+}


### PR DESCRIPTION
## 摘要

将 [`tianxia--/dsh-llm-local-token`](https://github.com/tianxia--/dsh-llm-local-token) 添加到 DeepSeek Harness 插件目录，分类 `model`。

该插件用本机 Codex CLI 与 Claude Code 已持有的 OAuth 凭据为 DSH 发起 LLM 调用，无需另配 API key：注册 `openai-codex`（凭据取自 `~/.codex/auth.json`）与 `anthropic`（取自 `~/.claude/.credentials.json`，否则取 macOS Keychain 中的 `Claude Code-credentials`）两条模型路由，缺少凭据的路由被跳过而不影响启动。
Token 按请求解析、临近过期时刷新，并交给 DSH 自带的 pi-ai 引擎，不派生引擎、不额外起代理进程。
客户端面板按计划读取各提供方的 rate-limit 响应头，显示订阅剩余额度；同时报告 pi-ai 内置 `zai-coding-cn` 路由的 GLM Coding Plan 额度。

- 仓库：https://github.com/tianxia--/dsh-llm-local-token （release v1.5.1，MIT，Node >= 22.13.0）
- npm：https://www.npmjs.com/package/dsh-llm-local-token （latest 1.5.1，`dsh plugin add dsh-llm-local-token`）

## 插件验证

- Manifest：`package.json`（默认分支 `main` 根目录，声明 `dsh.bundle.patch` 为 `./cordis.patch.yml`）
- Bundle patch：`cordis.patch.yml`（已提交在同一版本）
- 测试命令：`dsh plugin add dsh-llm-local-token`（DSH 0.1.2-alpha.2 / Node v22.22.2 / macOS，web profile）
- 测试结果：1.5.1 装入 `~/.dsh/profiles`（`profiles/web/cordis.patch.yml` 载入该插件）；`openai-codex` 与 `anthropic` 两条路由均已注册并在 Web 面板中显示实时剩余额度，其中 `anthropic` 的凭据取自 macOS Keychain 条目 `Claude Code-credentials`（本机无 `~/.claude/.credentials.json`，即文档所述的回退路径生效）

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件（`catalog/plugins/tianxia--dsh-llm-local-token.json`），不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 已按 `CONTRIBUTING.md` 与 `skills/submit-dsh-plugin` 操作：条目由 `skills/submit-dsh-plugin/scripts/create-catalog-entry.mjs` 生成；本地运行 `node scripts/review-plugin-submission.mjs` 得到 `VERDICT auto-merge`，`npm test` 6 个套件 99 项全部通过
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿新增类 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与两个 README，且收录不代表对插件行为、安全性或质量的背书

