### PR TITLE
catalog: add dsh-client-ui-brand

### DIFF
--- a/catalog/plugins/ningbonb--dsh-client-ui-brand.json
+++ b/catalog/plugins/ningbonb--dsh-client-ui-brand.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ningbonb/dsh-client-ui-brand",
+  "name": "dsh-client-ui-brand",
+  "repository": "https://github.com/ningbonb/dsh-client-ui-brand",
+  "category": "ui",
+  "description": {
+    "en": "Customizes the DeepSeek Harness Web product name, logo, favicon, and PWA icons without modifying core.",
+    "zh": "不修改 DeepSeek Harness Core，自定义 Web 端产品名称、Logo、浏览器图标和 PWA 图标。"
+  },
+  "added": "2026-09-02"
+}


### PR DESCRIPTION
## Plugin

https://github.com/ningbonb/dsh-client-ui-brand — Customizes the DeepSeek Harness Web product name, logo, favicon, and PWA icons without modifying core.

## Author verification

Ran `node_modules/.bin/vitest run` in the plugin repository: 1 test file passed, 9 tests passed.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically