### PR TITLE
catalog: add dsh-web-desktop

### DIFF
--- a/catalog/plugins/ningbonb--dsh-web-desktop.json
+++ b/catalog/plugins/ningbonb--dsh-web-desktop.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ningbonb/dsh-web-desktop",
+  "name": "dsh-web-desktop",
+  "repository": "https://github.com/ningbonb/dsh-web-desktop",
+  "category": "ui",
+  "description": {
+    "en": "Launches an Electron window for an existing DeepSeek Harness Web profile while sharing its plugins, sessions, and settings.",
+    "zh": "为现有 DeepSeek Harness Web profile 启动 Electron 窗口，并共享插件、会话和设置。"
+  },
+  "added": "2026-09-02"
+}


### PR DESCRIPTION
## Plugin

https://github.com/ningbonb/dsh-web-desktop — Launches an Electron window for an existing DeepSeek Harness Web profile while sharing its plugins, sessions, and settings.

## Author verification

Ran `node_modules/.bin/vitest run` in the plugin repository: 1 test file passed, 2 tests passed.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically