### PR TITLE
catalog: add CultOfLuna/dsh-vision-autoswitch

### DIFF
--- a/catalog/plugins/cultofluna--dsh-vision-autoswitch.json
+++ b/catalog/plugins/cultofluna--dsh-vision-autoswitch.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "CultOfLuna/dsh-vision-autoswitch",
+  "name": "dsh-vision-autoswitch",
+  "repository": "https://github.com/CultOfLuna/dsh-vision-autoswitch",
+  "category": "model",
+  "description": {
+    "en": "Routes image-bearing requests to the deepseek-v4-flash-vision-exp vision model, then falls back to the previously selected model when the turn ends.",
+    "zh": "当请求包含图片时，自动将该回合切换到视觉模型 deepseek-v4-flash-vision-exp 处理，回合结束后回落到之前选择的模型。"
+  },
+  "added": "2026-09-02"
+}


### PR DESCRIPTION
## 摘要

将 [`CultOfLuna/dsh-vision-autoswitch`](https://github.com/CultOfLuna/dsh-vision-autoswitch) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：装入 profile 的 `node_modules`，在 `cordis.patch.yml` 插入 `vision-autoswitch` 后热重载，发送含图与纯文本回合
- 测试结果：含图回合路由到 `deepseek-v4-flash-vision-exp`；回合结束后纯文本回合回落到原选模型（session JSONL 验证回落）

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
