### PR TITLE
Add dsh-super-pm plugin entry

### DIFF
--- a/catalog/plugins/lohaslee--dsh-super-pm.json
+++ b/catalog/plugins/lohaslee--dsh-super-pm.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Lohaslee/dsh-super-pm",
+  "name": "dsh-super-pm",
+  "repository": "https://github.com/Lohaslee/dsh-super-pm",
+  "category": "skill",
+  "description": {
+    "en": "Product-thinking companion for DeepSeek Harness: clarifies negative boundaries first, separates facts from assumptions, routes through seven product lenses, and persists confirmed decisions to project memory.",
+    "zh": "DeepSeek Harness 的产品思考助手：先明确负向边界，拆开事实与假设，经七套产品视角讨论取舍，并将确认的决策沉淀到项目记忆中。"
+  },
+  "added": "2026-09-02"
+}


### PR DESCRIPTION
## Summary

Add [dsh-super-pm](https://github.com/Lohaslee/dsh-super-pm) to the 1024 Store catalog.

**What it does:** Product-thinking companion for DeepSeek Harness: clarifies negative boundaries first, separates facts from assumptions, routes through seven product lenses, and persists confirmed decisions to project memory.

**Category:** `skill`

**Verification:**
- `dsh.bundle.patch` declared in `package.json`
- `cordis.patch.yml` present
- npm package `dsh-super-pm` published
- `dsh-plugin` GitHub topic set
- 14 commits, repo created 2026-09-01