### PR TITLE
Add dsh-whale-clock plugin

### DIFF
--- a/catalog/plugins/tingao--dsh-whale-clock.json
+++ b/catalog/plugins/tingao--dsh-whale-clock.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "tingao/dsh-whale-clock",
+  "name": "dsh-whale-clock",
+  "repository": "https://github.com/tingao/dsh-whale-clock",
+  "category": "ui",
+  "description": {
+    "en": "Corner widget for the DeepSeek Harness web GUI: an animated DeepSeek whale shows the current local time and a live countdown to the next DeepSeek pricing-window boundary, turning red during peak-price windows (01:00-04:00 and 06:00-10:00 UTC) and green during off-peak windows. Windows are classified in UTC and displayed in the browser's local timezone.",
+    "zh": "DeepSeek Harness Web 界面角落小部件：动画鲸鱼显示当前本地时间，并实时倒计时到下一个 DeepSeek 计费时段边界；高峰计价时段（UTC 01:00-04:00 与 06:00-10:00）变红，低谷时段变绿。按 UTC 判定计价时段，并按浏览器本地时区显示。"
+  },
+  "added": "2026-09-04"
+}


### PR DESCRIPTION
Adds the curated catalog entry for the dsh-whale-clock plugin (https://github.com/tingao/dsh-whale-clock, category: ui).

The repository declares \dsh.bundle.patch: ./cordis.patch.yml\ and the patch file is committed. The package is not yet published to npm, so the plugin will be listed browse-only with its repository link.