### PR TITLE
feat: add dsh-code-navigator

### DIFF
--- a/catalog/plugins/islulua--dsh-code-navigator--packages--code-navigator.json
+++ b/catalog/plugins/islulua--dsh-code-navigator--packages--code-navigator.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Islulua/dsh-code-navigator/packages/code-navigator",
+  "name": "dsh-code-navigator",
+  "repository": "https://github.com/Islulua/dsh-code-navigator",
+  "category": "tools",
+  "description": {
+    "en": "Persistent C/C++, Python, and TypeScript definition navigation with an optional standalone workspace UI for DeepSeek Harness.",
+    "zh": "为 DeepSeek Harness 提供持久化的 C/C++、Python 和 TypeScript 定义跳转，以及可独立运行的工作区界面。"
+  },
+  "added": "2026-09-04"
+}


### PR DESCRIPTION
Adds the published `dsh-code-navigator@0.1.0` plugin catalog entry. The public repository is https://github.com/Islulua/dsh-code-navigator and the installable npm package includes its `dsh.bundle.patch` declaration.