### PR TITLE
Add WongYuYe/dsh-appshots

### DIFF
--- a/catalog/plugins/wongyuye--dsh-appshots.json
+++ b/catalog/plugins/wongyuye--dsh-appshots.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "WongYuYe/dsh-appshots",
+  "name": "dsh-appshots",
+  "repository": "https://github.com/WongYuYe/dsh-appshots",
+  "category": "tools",
+  "description": {
+    "en": "Codex-style Appshots for DSH Desktop on macOS: press both Command keys to capture the frontmost window and attach it to the current chat.",
+    "zh": "给 DSH Desktop 用的 Codex 风格 Appshots：按两边 Command 捕获当前前台窗口，并附加到当前会话。"
+  },
+  "added": "2026-09-04"
+}


### PR DESCRIPTION
Add `WongYuYe/dsh-appshots`.

Codex-style Appshots for DSH Desktop on macOS: press both Command keys (or the composer camera button) to capture the frontmost window and attach it to the current chat.

- Repo: https://github.com/WongYuYe/dsh-appshots
- npm: https://www.npmjs.com/package/dsh-appshots (`dsh-appshots@0.1.0`)
- Category: tools
- Declares `dsh.bundle` + client platform web
- Topic: `dsh-plugin`
