### PR TITLE
catalog: add ice5kysl/dsh-workspace-kit

### DIFF
--- a/catalog/plugins/ice5kysl--dsh-workspace-kit.json
+++ b/catalog/plugins/ice5kysl--dsh-workspace-kit.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ice5kysl/dsh-workspace-kit",
+  "name": "dsh-workspace-kit",
+  "repository": "https://github.com/ice5kysl/dsh-workspace-kit",
+  "category": "ui",
+  "description": {
+    "en": "Workspace-first enhanced sidebar for dsh Web that shadows the built-in workspace browser at low priority (one-click toggle back to the official one) and adds soft workspace archive/restore, per-workspace SVG icons and accent colors, drag reorder and title/path/session-content search, plus a ⌘K Spotlight palette fuzzy-searching workspaces and sessions; the host half ships read-only workspace_find/workspace_list model tools and /workspace-find /workspace-list slash commands. Bilingual zh/en.",
+    "zh": "面向 dsh Web 的工作区优先增强侧栏：以低优先级 shadow 内置工作区浏览器（可一键切回官方版），提供软归档/恢复、每工作区 SVG 图标与强调色、拖拽排序与标题/路径/会话内容搜索；另提供 ⌘K Spotlight 面板模糊搜索工作区/会话；宿主侧附带只读 workspace_find/workspace_list 工具与 /workspace-find /workspace-list 斜杠命令（中英双语）。"
+  },
+  "added": "2026-09-05"
+}


### PR DESCRIPTION
## catalog: add ice5kysl/dsh-workspace-kit (ui)

A standard Cordis "bundle" plugin for DeepSeek Harness (dsh Web GUI), MIT, bilingual zh/en: an enhanced workspace sidebar that shadows the built-in workspace browser (`sidebar.workspaces`, priority −1, one-click toggle back to the official one) and adds soft workspace archive/restore, per-workspace SVG icons + accent colors, drag reorder and title/path/session-content search, plus a ⌘K/Ctrl+K Spotlight palette on the official `shell.overlay` slot; the host half registers read-only `workspace_find`/`workspace_list` tools and `/workspace-find` `/workspace-list` slash commands. Targets `@deepseek-ai/dsh` ≥ 0.1.1-rc.2; known limitations documented in the repo.

The repo declares a `dsh.bundle` manifest (committed `cordis.patch.yml`) and carries the `dsh-plugin` topic. Published to npm as `dsh-workspace-kit@0.1.0`.

Checklist:
- [x] Added exactly one new file: `catalog/plugins/ice5kysl--dsh-workspace-kit.json`
- [x] No changes outside `catalog/plugins/`
- [x] Description factual (en + zh), no marketing or invented features
- [x] Repo declares `dsh.bundle.patch`; patch file committed
- [x] Repo carries the `dsh-plugin` topic
