### PR TITLE
catalog: add ice5kysl/dsh-file-explorer-kit

### DIFF
--- a/catalog/plugins/ice5kysl--dsh-file-explorer-kit.json
+++ b/catalog/plugins/ice5kysl--dsh-file-explorer-kit.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "ice5kysl/dsh-file-explorer-kit",
+  "name": "dsh-file-explorer-kit",
+  "repository": "https://github.com/ice5kysl/dsh-file-explorer-kit",
+  "category": "ui",
+  "description": {
+    "en": "In-session \"Files\" tab (conversation.view, order 20) for dsh Web that browses the active session's workspace directory with breadcrumbs and previews files inline — sanitized Markdown (marked + DOMPurify), images, line-numbered text and PDF — served by read-only /dsh-files host routes registered on ctx.webServer; no write endpoints. Bilingual zh/en.",
+    "zh": "dsh Web 会话内「文件」页签（conversation.view，order 20）：以当前会话工作区为根的面包屑目录浏览，内联预览消毒渲染的 Markdown（marked + DOMPurify）、图片、带行号文本与 PDF；目录与读取全部经 ctx.webServer 注册的只读 /dsh-files 宿主路由，无任何写端点（中英双语）。"
+  },
+  "added": "2026-09-05"
+}


### PR DESCRIPTION
## catalog: add ice5kysl/dsh-file-explorer-kit (ui)

A standard Cordis "bundle" plugin for DeepSeek Harness (dsh Web GUI), MIT, bilingual zh/en: an in-session "Files" tab (`conversation.view`, order 20) that browses the active session's workspace directory with breadcrumbs and previews files inline — sanitized Markdown (marked + DOMPurify), images, line-numbered text (long files truncated), PDF. Directory listing and reads go through read-only `/dsh-files/*` host routes registered on `ctx.webServer`; there are no write endpoints, and the plugin coexists with dsh-workspace-kit (additive slot only). Targets `@deepseek-ai/dsh` ≥ 0.1.1-rc.2.

The repo declares a `dsh.bundle` manifest (committed `cordis.patch.yml`) and carries the `dsh-plugin` topic. Published to npm as `dsh-file-explorer-kit@0.3.1` (the plain `dsh-file-explorer` name belongs to an unrelated plugin; do not use it).

Checklist:
- [x] Added exactly one new file: `catalog/plugins/ice5kysl--dsh-file-explorer-kit.json`
- [x] No changes outside `catalog/plugins/`
- [x] Description factual (en + zh), no marketing or invented features
- [x] Repo declares `dsh.bundle.patch`; patch file committed
- [x] Repo carries the `dsh-plugin` topic
