### PR TITLE
docs: add xgone/dsh-netshell

### DIFF
--- a/catalog/plugins/xgone--dsh-netshell.json
+++ b/catalog/plugins/xgone--dsh-netshell.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "xgone/dsh-netshell",
+  "name": "dsh-netshell",
+  "repository": "https://github.com/xgone/dsh-netshell",
+  "category": "tools",
+  "description": {
+    "en": "Local and remote SSH terminals for DeepSeek Harness Web with three permission levels, human approval for risky AI commands, and encrypted credential storage.",
+    "zh": "DeepSeek Harness Web 的本地与远程 SSH 终端：提供三级权限，危险 AI 命令需真人确认，凭据加密存储。"
+  },
+  "added": "2026-09-05"
+}


### PR DESCRIPTION
## Summary

Add the repository-level catalog entry for `xgone/dsh-netshell`.

The plugin is a published npm package with a `dsh.bundle` patch manifest. It provides local and remote SSH terminals for DeepSeek Harness Web, three permission levels, human approval for risky AI commands, and encrypted credential storage.

This PR adds only `catalog/plugins/xgone--dsh-netshell.json`, as required by the catalog contribution guide.
