### PR TITLE
docs: add xgone/dsh-remote

### DIFF
--- a/catalog/plugins/xgone--dsh-remote.json
+++ b/catalog/plugins/xgone--dsh-remote.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "xgone/dsh-remote",
+  "name": "dsh-remote",
+  "repository": "https://github.com/xgone/dsh-remote",
+  "category": "security",
+  "description": {
+    "en": "Secure remote access for the DeepSeek Harness Web UI: a login gate, MFA/TOTP, signed session cookies, optional admin/user/guest roles, in-browser workspace selection, and allowlisted remote file previews.",
+    "zh": "为 DeepSeek Harness Web UI 提供安全远程访问：登录门禁、MFA/TOTP、签名会话 Cookie、可选的 admin/user/guest 角色、浏览器内工作区选择和按允许目录限制的远程文件预览。"
+  },
+  "added": "2026-09-05"
+}

--- a/catalog/plugins/xgone--dsh-remote.json
+++ b/catalog/plugins/xgone--dsh-remote.json
@@ -3,7 +3,7 @@
   "id": "xgone/dsh-remote",
   "name": "dsh-remote",
   "repository": "https://github.com/xgone/dsh-remote",
-  "category": "security",
+  "category": "tools",
   "description": {
     "en": "Secure remote access for the DeepSeek Harness Web UI: a login gate, MFA/TOTP, signed session cookies, optional admin/user/guest roles, in-browser workspace selection, and allowlisted remote file previews.",
     "zh": "为 DeepSeek Harness Web UI 提供安全远程访问：登录门禁、MFA/TOTP、签名会话 Cookie、可选的 admin/user/guest 角色、浏览器内工作区选择和按允许目录限制的远程文件预览。"


### PR DESCRIPTION
## Summary

Add `xgone/dsh-remote` as one catalog entry in `catalog/plugins/xgone--dsh-remote.json`.

The plugin provides a login gate, MFA/TOTP, signed session cookies, optional roles, browser-based workspace selection, and allowlisted remote file previews for the DeepSeek Harness Web UI.

Only the new catalog JSON file is included in this pull request.
