### PR TITLE
Add OwnDsh team model management plugin

### DIFF
--- a/catalog/plugins/boe1900--owndsh--plugin--packages--bundle.json
+++ b/catalog/plugins/boe1900--owndsh--plugin--packages--bundle.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "boe1900/owndsh/plugin/packages/bundle",
+  "name": "owndsh-plugin",
+  "repository": "https://github.com/boe1900/owndsh",
+  "category": "model",
+  "description": {
+    "en": "Early-stage plugin connecting DeepSeek Harness to a separately deployed, self-hosted OwnDsh server for team identity, model access control, quotas, and usage auditing.",
+    "zh": "早期开发中的团队管理插件，将 DeepSeek Harness 接入独立部署的自托管 OwnDsh 服务端，提供团队身份、模型授权、配额与用量审计。"
+  },
+  "added": "2026-09-05"
+}


### PR DESCRIPTION
## Plugin

[OwnDsh](https://github.com/boe1900/owndsh) connects DeepSeek Harness to a separately deployed, self-hosted server for team identity, managed model access, quotas, and usage auditing. The installable plugin lives at [`plugin/packages/bundle`](https://github.com/boe1900/owndsh/tree/main/plugin/packages/bundle), so the catalog id pins that subdirectory.

This adds exactly one new catalog entry in the `model` category.

## Stage and installation

OwnDsh is an early-development, unofficial community project. It requires an OwnDsh Server deployment and is intended for test environments and feedback at this stage.

The current working npm channel is `owndsh-plugin@next` (`0.1.0-beta.2`). The old `latest` package is `0.0.1` and does not declare `dsh.bundle`. This submission requests directory inclusion and does not claim Desktop marketplace automatic-install compatibility. A browse-only listing is appropriate until the market's npm installation requirements are met.

```sh
dsh plugin --profile web add --ignore-scripts owndsh-plugin@next
```

Use the actual Harness/Desktop profile, restart, configure the OwnDsh Server address, and sign in. The published prerelease may lag behind `main`. Known issues remain around managed-plugin profile state, package-manager deadlines, and waiting for uninstall during disposal.

## Author verification

- From the repository's `plugin/` directory, `pnpm --filter owndsh-plugin test` passed: 1 test file, 3 tests. This verifies the current source bundle's composition and contracts.
- The published `0.1.0-beta.2` tarball matches the npm registry's SHA-512 integrity value and contains `lib/index.js`, `lib/client.js`, and the declared `cordis.patch.yml`. Both JavaScript entries passed `node --input-type=module --check`.
- The maintainer's local regression screenshots show console login/model management, the OwnDsh login inside DSH Desktop 2.0.5, and a completed model conversation: [project discussion](https://github.com/deepseek-ai/deepseek-harness/discussions/5693).

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files.
- [x] New plugin: this PR adds exactly one entry; a passing non-draft review is merged automatically.
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file.
- [x] Plugin behavior and compatibility were tested by the author as described above.
- [x] `dsh-plugin` topic added.
- [x] English and Chinese descriptions are neutral and accurate.
- [x] I understand that failed reviews leave the PR open for corrections, and merged entries sync to the website and generated directories.

Existing-entry update/removal rules are not applicable to this new entry.
