### PR TITLE
Add jcaiagent7143-ui/linkdigest-mcp

### DIFF
--- a/catalog/plugins/jcaiagent7143-ui--linkdigest-mcp.json
+++ b/catalog/plugins/jcaiagent7143-ui--linkdigest-mcp.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "jcaiagent7143-ui/linkdigest-mcp",
+  "name": "linkdigest-mcp",
+  "repository": "https://github.com/jcaiagent7143-ui/linkdigest-mcp",
+  "category": "tools",
+  "description": {
+    "en": "Mounts a hosted MCP server that turns a Xiaohongshu, Douyin, TikTok, YouTube or X link into text: transcript with timecodes, on-screen text, a description and OCR of every image, caption and metadata.",
+    "zh": "挂载一个托管的 MCP 服务，把小红书、抖音、TikTok、YouTube 或 X 链接转成文本：带时间戳的转写、屏幕文字、逐图描述与 OCR、正文与元数据。"
+  },
+  "added": "2026-09-05"
+}


### PR DESCRIPTION
Adds exactly one new source entry: `catalog/plugins/jcaiagent7143-ui--linkdigest-mcp.json`. Nothing outside `catalog/plugins/` is touched.

**What it does.** Mounts a hosted MCP server through the official `@deepseek-ai/dsh-mcp-client` bridge. One tool, `digest_url(url, format, job_id)`: give it a post URL and it returns Markdown or JSON containing the transcript with timecodes, on-screen text, a description and OCR of every image, the caption and metadata. Long media exceeds a single request budget, so a call can return a job id to collect on a second call.

**Against the checklist:**

1. `package.json` declares a non-empty `dsh.bundle.patch` pointing at `./cordis.patch.yml`, and that patch file is committed at the repository root, in the same revision.
2. Tested it myself — `dsh plugin --profile web add "github:jcaiagent7143-ui/linkdigest-mcp#main"` installs, `dsh plugin list` shows `dsh-linkdigest@1.0.0`, and it appears in the profile's `dsh.profile.bundles` beside `@deepseek-ai/dsh-base` and `@deepseek-ai/dsh-web-app`.
3. The `dsh-plugin` topic is on the repository.
4. Filename derived from the id as specified: `jcaiagent7143-ui/linkdigest-mcp` → `jcaiagent7143-ui--linkdigest-mcp.json`, flat in `catalog/plugins/`.
5. Descriptions are factual and specific, with no superlatives or calls to action.
6. `added` is `2026-09-05`, today.
7. One file, nothing else.

**On installability:** there is no published npm package, so I expect this to be listed browse-only with the repository link. Noting it up front rather than having the bot point it out.

**Scope note, since the descriptions only claim what was measured:** Xiaohongshu, Douyin, TikTok, YouTube, X and web articles work. Bilibili does not — it returns HTTP 412 to our server's address. Instagram is wired but not verified end to end, and Facebook is out of scope because it serves no post content to logged-out requests. None of those are claimed in the catalog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpGW9DbqX9bkgv4RTETBmV
