### PR TITLE
Add DSH Connect

### DIFF
--- a/catalog/plugins/canary-builds--dhs-connect.json
+++ b/catalog/plugins/canary-builds--dhs-connect.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Canary-Builds/dhs-connect",
+  "name": "DSH Connect",
+  "repository": "https://github.com/Canary-Builds/dhs-connect",
+  "category": "model",
+  "description": {
+    "en": "Connects DeepSeek Harness to ChatGPT models through OAuth sign-in using the official Codex app-server, without requiring an OpenAI API key.",
+    "zh": "通过官方 Codex app-server 的 OAuth 登录，将 ChatGPT 模型接入 DeepSeek Harness，无需 OpenAI API 密钥。"
+  },
+  "added": "2026-09-06"
+}


### PR DESCRIPTION
Adds DSH Connect as one catalog entry.

Connects DeepSeek Harness to ChatGPT models through OAuth sign-in using the official Codex app-server, without requiring an OpenAI API key.

Source: https://github.com/Canary-Builds/dhs-connect

Install: `dsh plugin --profile web add @canary-builds/dsh-connect`

The public repository includes an MIT license, root `dsh.bundle.patch` declaration, the referenced Cordis patch, and committed host/client runtime code. The scoped package is published on npm with its bundle metadata. Both descriptions are factual; only the canonical catalog JSON is changed. Compatibility and permissions are documented in the source README.
