### PR TITLE
Add DSH Mobile UI

### DIFF
--- a/catalog/plugins/canary-builds--dsh-mobile-ui.json
+++ b/catalog/plugins/canary-builds--dsh-mobile-ui.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Canary-Builds/dsh-mobile-ui",
+  "name": "DSH Mobile UI",
+  "repository": "https://github.com/Canary-Builds/dsh-mobile-ui",
+  "category": "ui",
+  "description": {
+    "en": "Adds touch-friendly navigation and standalone PWA layout improvements inside the existing DeepSeek Harness web interface.",
+    "zh": "在现有 DeepSeek Harness 网页界面中增强触屏导航和独立 PWA 模式布局。"
+  },
+  "added": "2026-09-06"
+}


### PR DESCRIPTION
Adds DSH Mobile UI as one catalog entry.

Adds touch-friendly navigation and standalone PWA layout improvements inside the existing DeepSeek Harness web interface.

Source: https://github.com/Canary-Builds/dsh-mobile-ui

Install: `dsh plugin --profile web add @canary-builds/dsh-mobile-ui`

The public repository includes an MIT license, root `dsh.bundle.patch` declaration, the referenced Cordis patch, and committed host/client runtime code. The scoped package is published on npm with its bundle metadata. Both descriptions are factual; only the canonical catalog JSON is changed. Compatibility and permissions are documented in the source README.
