### PR TITLE
catalog: add dsh-advisor-group

### DIFF
--- a/catalog/plugins/xingzhen199186--dsh-advisor-group.json
+++ b/catalog/plugins/xingzhen199186--dsh-advisor-group.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "xingzhen199186/dsh-advisor-group",
+  "name": "dsh-advisor-group",
+  "repository": "https://github.com/xingzhen199186/dsh-advisor-group",
+  "category": "model",
+  "description": {
+    "en": "Consult multiple expert advisor models in a retro CRT chat-group card. One ask_advisors call runs an auto-deepen pipeline (driver deep-question, advisor relay, synthesis conclusion) with real SSE streaming, 26 provider presets across 11 platforms, a configurable daily quota, stop/resume, and optional advisor tool calling (readonly/all/off).",
+    "zh": "主模型在专业/长尾/高风险或不确定问题上召集多个专家顾问模型，以复古 CRT 聊天组卡片展示。一次 ask_advisors 自动跑满自动深挖流水线（驱动模型追问 → 顾问接力 → 综合结论），真流式 SSE、11 个平台 26 个供应商预设、可配置每日配额、停止/继续聊天，以及可选的顾问工具调用（readonly/all/off）。"
+  },
+  "added": "2026-09-06"
+}


### PR DESCRIPTION
Add community catalog entry for dsh-advisor-group 0.0.1.

- Repository: https://github.com/xingzhen199186/dsh-advisor-group (public, topic: dsh-plugin)
- npm: dsh-advisor-group@0.0.1 (latest), declares dsh.bundle.patch -> cordis.patch.yml
- One new catalog/plugins JSON per CONTRIBUTING fast path; schema-validated by the static gate.