### PR TITLE
Add dsh-thoughtdag context canvas plugin

### DIFF
--- a/catalog/plugins/chenxiachan--thoughtdag--dsh.json
+++ b/catalog/plugins/chenxiachan--thoughtdag--dsh.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "chenxiachan/thoughtdag/dsh",
+  "name": "dsh-thoughtdag",
+  "repository": "https://github.com/chenxiachan/thoughtdag",
+  "category": "tools",
+  "description": {
+    "en": "Adds an editable context canvas to the DeepSeek Harness web UI. Open local agent sessions as graphs, connect selected material to a question, and run canvas questions with the harness's models or agent. Includes local conversation lookup tools.",
+    "zh": "在 DeepSeek Harness Web 界面中加入可编辑的上下文画布。将本地 Agent 会话打开为图，把选定材料连入问题，并使用 Harness 的模型或 Agent 在画布上提问。附带本地会话检索工具。"
+  },
+  "added": "2026-09-06"
+}


### PR DESCRIPTION
## Add dsh-thoughtdag

Disclosure: I maintain ThoughtDAG and this plugin.

Adds one source entry for the monorepo subpackage `chenxiachan/thoughtdag/dsh`. The package adds ThoughtDAG's editable context canvas inside the DeepSeek Harness web UI.

- Source: https://github.com/chenxiachan/thoughtdag/tree/main/dsh
- Published npm package: `dsh-thoughtdag@0.4.5`
- Manifest: `dsh/package.json`, with `dsh.bundle.patch: ./cordis.patch.yml`
- Patch is committed at `dsh/cordis.patch.yml`.
- Install: `dsh plugin --profile web add dsh-thoughtdag@0.4.5`
- Declared compatibility: DSH `0.1.2-rc.1`; Node `^22.19.0 || >=24.0.0`.
- Repository already has the `dsh-plugin` topic.

The maintainer's local verification and reproduction steps are documented in the [plugin README](https://github.com/chenxiachan/thoughtdag/tree/main/dsh#verified-2026-09). This submission checks the published package metadata and committed manifest/patch; it does not claim a new cross-platform runtime test or a security audit.

Only `catalog/plugins/chenxiachan--thoughtdag--dsh.json` is changed. No generated README, workflows, or scripts are modified.
