### PR TITLE
catalog: add grloper/dsh-deep-research

### DIFF
--- a/catalog/plugins/grloper--dsh-deep-research.json
+++ b/catalog/plugins/grloper--dsh-deep-research.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "grloper/dsh-deep-research",
+  "name": "dsh-deep-research",
+  "repository": "https://github.com/grloper/dsh-deep-research",
+  "category": "tools",
+  "description": {
+    "en": "Registers verify_text, deep_research, compare_sources, check_source and research_recall. Citations are admitted only when the quoted span is located in the fetched source text by substring match; corroboration is counted in independent origins using MinHash and SCC condensation rather than raw source count. Findings persist in a local SQLite or JSON evidence store with per-claim freshness horizons.",
+    "zh": "注册 verify_text、deep_research、compare_sources、check_source 与 research_recall 五个工具。引用仅在引文片段能通过子串匹配定位到已抓取的原文时才被采纳；佐证按独立来源计数，使用 MinHash 与强连通分量缩点识别转载与改写，而非直接统计来源数量。结论保存在本地 SQLite 或 JSON 证据库中，并按claim 设置新鲜度期限。"
+  },
+  "added": "2026-09-06"
+}


### PR DESCRIPTION
Adds one new catalog entry: `grloper/dsh-deep-research`.

**What the plugin does**

Registers five tools with the harness: `verify_text`, `deep_research`, `compare_sources`, `check_source`, and `research_recall`.

Two mechanisms distinguish it from a retrieval wrapper:

- **Citation admission is mechanical.** The entailment judge is required to return a verbatim quote, and that quote must then be located in the fetched source text by substring match (exact, or normalized for whitespace/punctuation, with the match projected back to original character offsets). A quote that cannot be located is rejected and the claim is demoted to `UNVERIFIED`, so a fabricated citation fails deterministically rather than being assessed by another model.
- **Corroboration is counted in independent origins.** 3-gram shingles feed MinHash + LSH; documents above the syndication threshold, or sharing a long verbatim quote, are linked in a lineage DAG whose cycles are condensed with Tarjan's algorithm. The roots are counted, so twelve outlets carrying one wire story report as one origin rather than twelve sources.

**Checklist against CONTRIBUTING.md**

- `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml`, and that file is committed at the repository root.
- The `dsh-plugin` GitHub topic is set on the repository.
- Filename `grloper--dsh-deep-research.json` matches the id `grloper/dsh-deep-research`.
- Only this one file is added; no README, workflow, or script paths are touched.
- Both descriptions are factual and specific, describing the registered tools and the matching/aggregation methods without superlatives or calls to action.
- `added` is the submission date.

**Note on the existing similar name:** `omdsh-dev/dsh-deep-research` is already catalogued. That is an unrelated project by a different owner built on the official workflow engine; this entry is keyed by `grloper/dsh-deep-research` and does not modify the existing file.

Repository: https://github.com/grloper/dsh-deep-research
License: MIT · Zero runtime dependencies · CI green on Node 20/22/24 across Linux and Windows.
