### PR TITLE
catalog: add grloper/dsh-claude-oauth

### DIFF
--- a/catalog/plugins/grloper--dsh-claude-oauth.json
+++ b/catalog/plugins/grloper--dsh-claude-oauth.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "grloper/dsh-claude-oauth",
+  "name": "dsh-claude-oauth",
+  "repository": "https://github.com/grloper/dsh-claude-oauth",
+  "category": "model",
+  "description": {
+    "en": "Adds a Claude section to Web Settings that runs a PKCE OAuth flow over an ephemeral dual-stack loopback callback server, so a Claude Pro or Max subscription can be used as a model provider without pasting tokens. Exchanged credentials are written to ~/.claude/.credentials.json and ~/.dsh/.credentials.yaml, the model list is read from the /v1/models endpoint, and 5-hour and 7-day subscription quota usage is shown with reset countdowns.",
+    "zh": "在 Web 设置中新增 Claude 板块，通过临时的双栈回环回调服务器执行 PKCE OAuth 流程，使 Claude Pro 或 Max 订阅可作为模型提供方使用，无需手动粘贴令牌。交换所得凭据写入 ~/.claude/.credentials.json 与 ~/.dsh/.credentials.yaml，模型列表读取自 /v1/models 接口，并展示 5 小时与 7 天订阅额度用量及重置倒计时。"
+  },
+  "added": "2026-09-06"
+}


### PR DESCRIPTION
Adds one new catalog entry: `grloper/dsh-claude-oauth`.

**What the plugin does**

Registers a Claude model provider and a Settings section, so a Claude Pro or Max subscription can be used from the harness without manually dumping or pasting tokens.

- **PKCE OAuth in the browser.** Sign-in runs against an ephemeral loopback callback server bound on both `127.0.0.1` and `::1`, which avoids the Windows localhost resolution mismatch that breaks single-stack callback listeners.
- **Credential sync.** Exchanged tokens are written to `~/.claude/.credentials.json` (shared with the official Claude Code CLI) and `~/.dsh/.credentials.yaml`, and the provider entry is configured in `~/.dsh/settings.yaml`.
- **Live model catalog.** The model list is read from `GET /v1/models` rather than hardcoded, so newly released Claude models appear without a plugin update.
- **Quota visibility.** The 5-hour and 7-day subscription quota windows are displayed with utilization and reset countdowns in Settings and in the composer dock.

**Checklist against CONTRIBUTING.md**

- `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml`, and that file is committed at the repository root.
- The `dsh-plugin` GitHub topic is set on the repository.
- Filename `grloper--dsh-claude-oauth.json` matches the id `grloper/dsh-claude-oauth`.
- Only this one file is added; no README, workflow, or script paths are touched.
- Both descriptions state the mechanism and the files touched, without superlatives or calls to action.
- `added` is the submission date.

Repository: https://github.com/grloper/dsh-claude-oauth
License: MIT · English and Simplified Chinese READMEs included.
