### PR TITLE
catalog: add Busabase DSH plugin

### DIFF
--- a/catalog/plugins/busabase--busabase-dsh-plugin.json
+++ b/catalog/plugins/busabase--busabase-dsh-plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "busabase/busabase-dsh-plugin",
+  "name": "busabase-dsh-plugin",
+  "repository": "https://github.com/busabase/busabase-dsh-plugin",
+  "category": "tools",
+  "description": {
+    "en": "Connects DeepSeek Harness to Busabase for structured data and approved knowledge, rendering workspace entities as cards and proposing writes for human review.",
+    "zh": "将 DeepSeek Harness 连接到 Busabase，用于结构化数据和已批准知识；以卡片呈现工作区实体，并将写入作为待人工审核的提案。"
+  },
+  "added": "2026-09-07"
+}


### PR DESCRIPTION
Adds one catalog entry for busabase/busabase-dsh-plugin.

Checklist:
- The public repository has the dsh-plugin topic.
- Its published npm package, @busabase/dsh-plugin@0.1.4, declares dsh.bundle.patch and commits cordis.patch.yml.
- The PR adds only catalog/plugins/busabase--busabase-dsh-plugin.json.
- The target repository static review passed locally with VERDICT auto-merge.

The plugin connects DeepSeek Harness to Busabase for structured data and approved knowledge, renders workspace entities as cards, and proposes writes for human review.

Note: the package documented direct installation requires:
dsh1024 plugin --profile web add --allow-build=@busabase/dsh-plugin @busabase/dsh-plugin

Disclosure: I work on Busabase.