### PR TITLE
catalog: add scwlkq/dsh-second-opinion

### DIFF
--- a/catalog/plugins/scwlkq--dsh-second-opinion.json
+++ b/catalog/plugins/scwlkq--dsh-second-opinion.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "scwlkq/dsh-second-opinion",
+  "name": "dsh-second-opinion",
+  "repository": "https://github.com/scwlkq/dsh-second-opinion",
+  "category": "session",
+  "description": {
+    "en": "Asynchronously reviews each committed assistant message with a second model, shows quote-anchored concerns in DSH Web, and supports manual or bounded automatic reconsideration.",
+    "zh": "使用第二模型异步审阅每条已提交的 assistant 消息，在 DSH Web 中展示带原文引用的意见，并支持人工复议或有次数上限的自动复议。"
+  },
+  "added": "2026-09-07"
+}


### PR DESCRIPTION
## 摘要

将 [`scwlkq/dsh-second-opinion`](https://github.com/scwlkq/dsh-second-opinion) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`pnpm test`、`pnpm run typecheck`、`pnpm run lint`、`pnpm run build`、`DSH_SOURCE_ROOT=<local DeepSeek Harness checkout> pnpm run smoke:install`
- 测试结果：55 项测试通过；类型检查、Lint、构建通过；真实 tarball 安装到 DSH `0.1.2-rc.1` Web profile 通过。

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
