### PR TITLE
Add dsh-ui-appearance (kiligzzz custom fork)

### DIFF
--- a/catalog/plugins/kiligzzz--dsh-ui-appearance.json
+++ b/catalog/plugins/kiligzzz--dsh-ui-appearance.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "kiligzzz/dsh-ui-appearance",
+  "name": "dsh-ui-appearance (kiligzzz fork)",
+  "repository": "https://github.com/kiligzzz/dsh-ui-appearance",
+  "category": "theme",
+  "description": {
+    "en": "A customized fork of TQSY114514/dsh-ui-appearance for theme palettes, wallpapers, and glassmorphism, with a layout fix for duplicate blank space alongside better-sidebar 0.18.0.",
+    "zh": "基于 TQSY114514/dsh-ui-appearance 的定制 fork，提供主题调色、壁纸与毛玻璃，并修复与 better-sidebar 0.18.0 共用时的重复留白。"
+  },
+  "added": "2026-09-07"
+}


### PR DESCRIPTION
## Plugin
https://github.com/kiligzzz/dsh-ui-appearance

Adds one independent theme entry for a customized fork of https://github.com/TQSY114514/dsh-ui-appearance. Original attribution and all existing entries remain unchanged. Provides palettes, wallpapers, and glassmorphism. v0.1.7 removes this fork’s legacy #root width override to fix duplicate blank space alongside better-sidebar 0.18.0; this is not a claim that current upstream has the same defect.

Release: https://github.com/kiligzzz/dsh-ui-appearance/releases/tag/v0.1.7
Package: @kiligzzz/dsh-ui-appearance, not published to npm; browse-only listing is intentional.

## Author verification
- Author reports vitest run: 130 tests passed, bundle passed, and user GUI verification passed.
- Local catalog validator: all 576 entries passed; git diff --cached --check passed.
- Release and uploaded tarball verified with gh release view before commit.

## Catalog submissions
- [x] Only one new catalog/plugins/*.json file; non-draft submission.
- [x] dsh.bundle.patch and committed cordis.patch.yml verified.
- [x] dsh-plugin topic added.
- [x] Neutral English and Chinese descriptions.
- [x] Existing upstream entries and generated READMEs untouched.
- [x] I understand static review and automatic catalog/README refresh after merge.