### PR TITLE
Add JNNarrator/dsh-deckseek (ui)

### DIFF
--- a/catalog/plugins/jnnarrator--dsh-deckseek.json
+++ b/catalog/plugins/jnnarrator--dsh-deckseek.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "JNNarrator/dsh-deckseek",
+  "name": "dsh-deckseek",
+  "repository": "https://github.com/JNNarrator/dsh-deckseek",
+  "category": "ui",
+  "description": {
+    "en": "Reading-view enhancement for the DeepSeek Harness web client: auto-collapsing execution process, a message navigation rail, in-page search, unified failure cards, and generative MCP Apps (SEP-1865) rendered in sandboxed iframes.",
+    "zh": "DeepSeek Harness Web 客户端阅读视图增强：执行过程自动收起、消息导航导轨、页内查找、统一失败卡片，并支持在沙箱 iframe 中渲染生成式 MCP Apps（SEP-1865）。"
+  },
+  "added": "2026-09-07"
+}


### PR DESCRIPTION
新增一个 catalog 条目：`catalog/plugins/jnnarrator--dsh-deckseek.json`。

- 仓库 package.json 声明 `dsh.bundle.patch`（`./cordis.patch.yml`，patch 文件已提交）
- 已添加 `dsh-plugin` GitHub topic
- 分类 `ui`（UI 增强），描述为事实性陈述
- 说明：该插件尚未发布 npm，预计以 browse-only 状态上架；之后若发布 npm 包，目录会自动补上安装命令