### PR TITLE
Add runcat-tommy/dsh-view-manager

### DIFF
--- a/catalog/plugins/runcat-tommy--dsh-view-manager.json
+++ b/catalog/plugins/runcat-tommy--dsh-view-manager.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "runcat-tommy/dsh-view-manager",
+  "name": "dsh-view-manager",
+  "repository": "https://github.com/runcat-tommy/dsh-view-manager",
+  "category": "ui",
+  "description": {
+    "en": "View tab manager for the DeepSeek Harness Web GUI session header: enable, hide, reorder and rename the conversation view tabs (Chat / Trajectory), with locale-aware zh/en UI and npm update reminders.",
+    "zh": "DSH 视图标签管理器（逃咪）：管理会话页头视图标签（对话/轨迹）——启停、隐藏、排序与重命名，界面随语言中英切换，带 npm 更新提醒。"
+  },
+  "added": "2026-09-03"
+}


### PR DESCRIPTION
Add catalog entry for runcat-tommy/dsh-view-manager.

- Repository: https://github.com/runcat-tommy/dsh-view-manager
- Declares dsh.bundle.patch with the patch file committed.