### PR TITLE
Add runcat-tommy/dsh-plugin-runcat-inventory

### DIFF
--- a/catalog/plugins/runcat-tommy--dsh-plugin-runcat-inventory.json
+++ b/catalog/plugins/runcat-tommy--dsh-plugin-runcat-inventory.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "runcat-tommy/dsh-plugin-runcat-inventory",
+  "name": "dsh-plugin-runcat-inventory",
+  "repository": "https://github.com/runcat-tommy/dsh-plugin-runcat-inventory",
+  "category": "dev",
+  "description": {
+    "en": "Plugin inventory manager for DeepSeek Harness Web: table view of installed plugins with status filters, enable/disable switches applied via HMR, config viewer/copy, uninstall, and npm update reminders.",
+    "zh": "DSH 插件总览（逃咪）：以表格视图管理已安装插件，支持状态过滤、启用/停用开关（HMR 热生效）、配置查看/复制、卸载与 npm 更新提醒。"
+  },
+  "added": "2026-09-03"
+}


### PR DESCRIPTION
Add catalog entry for runcat-tommy/dsh-plugin-runcat-inventory.

- Repository: https://github.com/runcat-tommy/dsh-plugin-runcat-inventory
- Declares dsh.bundle.patch with the patch file committed.