### PR TITLE
Update dsh-appshots description for Windows support

### DIFF
--- a/catalog/plugins/wongyuye--dsh-appshots.json
+++ b/catalog/plugins/wongyuye--dsh-appshots.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/WongYuYe/dsh-appshots",
   "category": "tools",
   "description": {
-    "en": "Codex-style Appshots for DSH Desktop on macOS: press both Command keys to capture the frontmost window and attach it to the current chat.",
-    "zh": "给 DSH Desktop 用的 Codex 风格 Appshots：按两边 Command 捕获当前前台窗口，并附加到当前会话。"
+    "en": "Codex-style window capture for DSH Desktop on macOS and Windows: press both Command keys (macOS) or both Ctrl keys (Windows) to grab the frontmost window and attach it to the current chat.",
+    "zh": "给 DSH Desktop 用的窗口截图，支持 macOS 和 Windows：macOS 按两边 Command、Windows 按两边 Ctrl 捕获当前前台窗口并附加到会话。"
   },
   "added": "2026-09-04"
 }


### PR DESCRIPTION
Sync the dsh-appshots catalog card with Windows support.

Hotkeys: both Command keys on macOS, both Ctrl keys on Windows (or the composer camera button).