### PR TITLE
catalog: add dsh-insight-tree

### DIFF
--- a/catalog/plugins/xingzhen199186--dsh-insight-tree.json
+++ b/catalog/plugins/xingzhen199186--dsh-insight-tree.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "xingzhen199186/dsh-insight-tree",
+  "name": "dsh-insight-tree",
+  "repository": "https://github.com/xingzhen199186/dsh-insight-tree",
+  "category": "dev",
+  "description": {
+    "en": "Explainable DSH plugin observability and diagnostics: Profile and Loader state, DSH and companion-package compatibility, session activity, upstream release metadata, standalone startup-failure diagnosis, and guarded plugin operations.",
+    "zh": "可解释的 DSH 插件观测与诊断：Profile 与 Loader 状态、DSH 本体及配套包兼容性、会话活动、上游版本信息、独立启动失败诊断，以及带保护的插件操作。"
+  },
+  "added": "2026-09-07"
+}


### PR DESCRIPTION
## Submission

- Repository: https://github.com/xingzhen199186/dsh-insight-tree
- npm: https://www.npmjs.com/package/dsh-insight-tree
- Category: `dev`
- Current DSH host verified: `@deepseek-ai/dsh@0.1.2-rc.1`
- Public repository and `dsh-plugin` topic are in place.
- The entry is the only changed catalog file.

The plugin provides an explainable plugin tree, real Loader/Fiber state, session activity, upstream compatibility checks, standalone diagnostics, exports, and guarded enable/disable/uninstall operations.