### PR TITLE
catalog: add linsibin/dsh-task-board

### DIFF
--- a/catalog/plugins/linsibin--dsh-task-board.json
+++ b/catalog/plugins/linsibin--dsh-task-board.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "linsibin/dsh-task-board",
+  "name": "dsh-task-board",
+  "repository": "https://github.com/linsibin/dsh-task-board",
+  "category": "ui",
+  "description": {
+    "en": "Adds a Tasks kanban tab next to Chat and Trajectory in the DSH Desktop conversation header, with drag-to-execute task cards that create real agent sessions bound to each task working directory.",
+    "zh": "在 DSH Desktop 会话头部新增与对话、轨迹并列的任务看板页签，支持三栏 Kanban 与拖拽触发、按工作目录创建真实 Agent 会话执行任务。"
+  },
+  "added": "2026-09-08"
+}


### PR DESCRIPTION
## 摘要

将 [`linsibin/dsh-task-board`](https://github.com/linsibin/dsh-task-board) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`./cordis.patch.yml`
- 测试命令：`dsh plugin --profile desktop add F:\Work\RYV2-Beta2\Trunk\dsh-task-board`，重启 DSH Desktop；打开会话后验证「任务」页签、新建任务、拖入「进行中」触发 Agent 执行、完成后自动进入「完成」栏、刷新后任务仍在
- 测试结果：在 DSH Desktop 2.0.5 桌面 profile 上完成上述验收项；会话头部出现「任务」页签；拖拽执行后 Agent 正常回复；完成后自动流转；localStorage 持久化正常

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
