### PR TITLE
add Aealen/dsh-coding-workspace

### DIFF
--- a/catalog/plugins/aealen--dsh-coding-workspace.json
+++ b/catalog/plugins/aealen--dsh-coding-workspace.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Aealen/dsh-coding-workspace",
+  "name": "dsh-coding-workspace",
+  "repository": "https://github.com/Aealen/dsh-coding-workspace",
+  "category": "ui",
+  "description": {
+    "en": "Coding workbench for DSH: docked workspace panels, a grouped project sidebar, split editor tab groups with hibernate/resume, file preview and diff views, built on parallel git worktree development with cross-session collaboration primitives.",
+    "zh": "coding 工作台：停靠式工作区面板、项目分组侧栏、可休眠/恢复的分栏编辑器 TAB 组、文件预览与 DIFF 查看，以 git worktree 并行开发与跨会话协作为地基。"
+  },
+  "added": "2026-09-09"
+}


### PR DESCRIPTION
## 新增条目

- **插件**: [Aealen/dsh-coding-workspace](https://github.com/Aealen/dsh-coding-workspace)
- **分类**: ui
- `package.json` 声明非空 `dsh.bundle.patch`(`./cordis.patch.yml`),patch 文件已提交 ✓
- 已添加 `dsh-plugin` topic ✓

## 请求 maintainer 协助:清理改名前的自动条目

本仓库原名为 `dsh-worktree`,后更名为 `dsh-coding-workspace`。GitHub topic 自动收集管线收录的旧条目仍使用旧 id:

- 旧 id:`Aealen/dsh-worktree`(机器生成描述,category: dev,浏览模式)
- 新 id:`Aealen/dsh-coding-workspace`(本 PR)

两者 repository URL 相同,合并后数据库会出现重复条目。由于自动收集条目不在 `catalog/plugins/` 目录中、无法通过本 PR 清除,恳请 maintainer 从收集管线中移除旧条目 `Aealen/dsh-worktree`,谢谢!