### PR TITLE
Add dsh-capability-panel

### DIFF
--- a/catalog/plugins/pure-craft--dsh-capability-panel.json
+++ b/catalog/plugins/pure-craft--dsh-capability-panel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "pure-craft/dsh-capability-panel",
+  "name": "dsh-capability-panel",
+  "repository": "https://github.com/pure-craft/dsh-capability-panel",
+  "category": "ui",
+  "description": {
+    "en": "See which skills and tools your agent can actually reach right now — true in-context state (loaded/truncated/evicted) and per-session switches.",
+    "zh": "看清 agent 此刻真正能触达哪些技能与工具——真实的在上下文状态（已加载/已截断/已挤出），并按会话开关。"
+  },
+  "added": "2026-09-09"
+}


### PR DESCRIPTION
Adds [pure-craft/dsh-capability-panel](https://github.com/pure-craft/dsh-capability-panel) to the catalog.

**What it does:** A Web UI panel that shows which skills and tools your agent can actually reach right now — true in-context state (loaded/truncated/evicted) read from the live session surface, plus per-session switches persisted per session id.

**Install:**
```
dsh plugin --profile web add dsh-capability-panel
```

- `package.json` declares `dsh.bundle.patch` and the patch file is committed.
- npm package [`dsh-capability-panel`](https://www.npmjs.com/package/dsh-capability-panel) (v1.1.0) is published with the `dsh.bundle` declaration, so it is store-installable.
- Repository carries the `dsh-plugin` GitHub topic.
- Exactly one new file: `catalog/plugins/pure-craft--dsh-capability-panel.json` (no other paths touched).