### PR TITLE
catalog: add chromoany/dsh-notify-me

### DIFF
--- a/catalog/plugins/chromoany--dsh-notify-me.json
+++ b/catalog/plugins/chromoany--dsh-notify-me.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "chromoany/dsh-notify-me",
+  "name": "dsh-notify-me",
+  "repository": "https://github.com/chromoany/dsh-notify-me",
+  "category": "notify",
+  "description": {
+    "en": "Desktop notifications, sounds and a tab-title marker when the agent needs your input (approval, plan review, question) or a reply finishes in the background; toggleable in Settings with zh/en notification language.",
+    "zh": "模型需要你操作（审批、方案确认、提问）或后台回复完成时，弹出系统通知、提示音并标记标签页标题；可在设置页开关并切换通知语言。"
+  },
+  "added": "2026-09-09"
+}


### PR DESCRIPTION
Adds one new catalog entry: `catalog/plugins/chromoany--dsh-notify-me.json` (id `chromoany/dsh-notify-me`, category `notify`).

- `package.json` declares `dsh.bundle.patch` → `./cordis.patch.yml`, committed at the repo root
- published on npm as `dsh-notify-me@1.1.2`
- `dsh-plugin` topic is set

What it does: the plugin is a web client plugin that fires a desktop notification, a sound and a tab-title marker when the agent needs input (approval, plan review, question) or a reply finishes while the page is in the background; on/off and zh/en notification language are set from the Settings page.