### PR TITLE
feat: add dsh-workspace-monitor

### DIFF
--- a/catalog/plugins/rainier-z--dsh-workspace-monitor.json
+++ b/catalog/plugins/rainier-z--dsh-workspace-monitor.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "Rainier-Z/dsh-workspace-monitor",
+  "name": "dsh-workspace-monitor",
+  "repository": "https://github.com/Rainier-Z/dsh-workspace-monitor",
+  "category": "workflow",
+  "description": {
+    "en": "A DeepSeek Harness plugin that periodically detects added, modified, and deleted files in a workspace and reports the changes.",
+    "zh": "一个适配 DeepSeek Harness 的工作区监测插件，按周期检测并报告文件的新增、修改和删除。"
+  },
+  "added": "2026-09-10"
+}


### PR DESCRIPTION
## Plugin

[Rainier-Z/dsh-workspace-monitor](https://github.com/Rainier-Z/dsh-workspace-monitor) is a DeepSeek Harness plugin that periodically detects added, modified, and deleted files in a workspace and reports the changes.

## Author verification

- Published npm package: `dsh-workspace-monitor@0.1.3`
- Tested the package and plugin behavior locally; the project test suite passes (78 tests).
- Verified the package declares `dsh.bundle.patch` and includes the referenced `cordis.patch.yml`.

## Catalog submissions

- [x] This PR only touches `catalog/plugins/*.json` files
- [x] New plugin: this PR adds exactly one `catalog/plugins/*.json` file, so a passing non-draft review is merged automatically
- [ ] Update or removal of existing entries: I understand the static review still runs, but a maintainer reviews and merges such a PR manually
- [x] Repository declares `dsh.bundle.patch` and commits the referenced patch file (added or modified entries)
- [x] Plugin behavior and compatibility were tested by the author
- [x] `dsh-plugin` topic added
- [x] English and Chinese descriptions are neutral and accurate
- [x] I understand that a failed review leaves this PR open for corrections and never closes it, and that after any merge the website catalog and README directories refresh automatically