### PR TITLE
catalog: add dsh-plugin-update-audit

### DIFF
--- a/catalog/plugins/wcnm8888--dsh-plugin-update-audit.json
+++ b/catalog/plugins/wcnm8888--dsh-plugin-update-audit.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "wcnm8888/dsh-plugin-update-audit",
+  "name": "dsh-plugin-update-audit",
+  "repository": "https://github.com/wcnm8888/dsh-plugin-update-audit",
+  "category": "tools",
+  "description": {
+    "en": "Audits direct DeepSeek Harness Profile plugin dependencies against npm and GitHub while marking local package sources for manual review.",
+    "zh": "只读审计 DeepSeek Harness Profile 的直接插件依赖，对比 npm 与 GitHub 上游，并标记需要人工复核的本地包来源。"
+  },
+  "added": "2026-09-10"
+}


### PR DESCRIPTION
Adds the read-only dsh-plugin-update-audit catalog entry. The plugin audits direct DSH Profile dependencies against npm and GitHub, marks local package sources for manual review, and never performs updates. Local plugin tests pass 7/7 and the package was accepted by dev-lab from a local TGZ. The npm package is not published yet, so the entry is expected to be browse-only until registry publication.