### PR TITLE
catalog: add zhengjy01/dsh-zsxq

### DIFF
--- a/catalog/plugins/zhengjy01--dsh-zsxq.json
+++ b/catalog/plugins/zhengjy01--dsh-zsxq.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zhengjy01/dsh-zsxq",
+  "name": "dsh-zsxq",
+  "repository": "https://github.com/zhengjy01/dsh-zsxq",
+  "category": "tools",
+  "description": {
+    "en": "Knowledge Planet (知识星球 zsxq) integration for DeepSeek Harness: cookie/QR login against the unofficial web API (api.zsxq.com/v2), agent tools for groups / topic lists / topic detail / search / publish / comment / like, plus a web settings panel.",
+    "zh": "DeepSeek Harness 的知识星球（zsxq）集成：Cookie/扫码登录非官方 Web API（api.zsxq.com/v2），提供星球列表 / 主题列表 / 主题详情 / 搜索 / 发布 / 评论 / 点赞工具与 Web 设置面板。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
## 新增插件：`zhengjy01/dsh-zsxq`

本 PR 只新增一个 catalog 文件：`catalog/plugins/zhengjy01--dsh-zsxq.json`。

### 插件用途

接入知识星球（zsxq）非官方 Web API，支持 Cookie / 扫码登录，并提供星球列表、主题列表、主题详情、搜索、发布、评论、点赞等 agent 工具与 Web 设置面板。注意：星球无官方 API，读操作较稳定，写操作为非官方接口，可能触发风控。

### 基本信息

| 字段 | 值 |
| --- | --- |
| id | `zhengjy01/dsh-zsxq` |
| 仓库 | https://github.com/zhengjy01/dsh-zsxq |
| npm 包 | [`dsh-zsxq`](https://www.npmjs.com/package/dsh-zsxq) |
| category | `tools` |
| added | `2026-09-11` |

### 英文说明

Knowledge Planet (知识星球 zsxq) integration for DeepSeek Harness: cookie/QR login against the unofficial web API (api.zsxq.com/v2), agent tools for groups / topic lists / topic detail / search / publish / comment / like, plus a web settings panel.

### 中文说明

DeepSeek Harness 的知识星球（zsxq）集成：Cookie/扫码登录非官方 Web API（api.zsxq.com/v2），提供星球列表 / 主题列表 / 主题详情 / 搜索 / 发布 / 评论 / 点赞工具与 Web 设置面板。

已确认仓库根目录存在 `package.json` 且声明了 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件存在于同一 revision。
