### PR TITLE
catalog: add zhengjy01/dsh-skill-recommender

### DIFF
--- a/catalog/plugins/zhengjy01--dsh-skill-recommender.json
+++ b/catalog/plugins/zhengjy01--dsh-skill-recommender.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zhengjy01/dsh-skill-recommender",
+  "name": "dsh-skill-recommender",
+  "repository": "https://github.com/zhengjy01/dsh-skill-recommender",
+  "category": "skill",
+  "description": {
+    "en": "Session-profile driven open-source skill recommender for DeepSeek Harness: scans local DSH / Codex / Claude sessions, builds a weighted profile (topics, tools, tasks, projects) and recommends matching skills with a tunable match index.",
+    "zh": "DeepSeek Harness 的会话画像 skill 推荐器：扫描本地 DSH/Codex/Claude 会话建立加权画像（主题/工具/任务/项目），按可调匹配指数推荐开源 skill。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
## 新增插件：`zhengjy01/dsh-skill-recommender`

本 PR 只新增一个 catalog 文件：`catalog/plugins/zhengjy01--dsh-skill-recommender.json`。

### 插件用途

扫描本地 DSH / Codex / Claude 会话记录，构建加权画像（主题、工具、任务、项目），并按可调的「匹配指数」推荐合适的开源 skill，帮助发现值得安装的能力。

### 基本信息

| 字段 | 值 |
| --- | --- |
| id | `zhengjy01/dsh-skill-recommender` |
| 仓库 | https://github.com/zhengjy01/dsh-skill-recommender |
| npm 包 | [`dsh-skill-recommender`](https://www.npmjs.com/package/dsh-skill-recommender) |
| category | `skill` |
| added | `2026-09-11` |

### 英文说明

Session-profile driven open-source skill recommender for DeepSeek Harness: scans local DSH / Codex / Claude sessions, builds a weighted profile (topics, tools, tasks, projects) and recommends matching skills with a tunable match index.

### 中文说明

DeepSeek Harness 的会话画像 skill 推荐器：扫描本地 DSH/Codex/Claude 会话建立加权画像（主题/工具/任务/项目），按可调匹配指数推荐开源 skill。

已确认仓库根目录存在 `package.json` 且声明了 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件存在于同一 revision。
