### PR TITLE
catalog: add zhengjy01/dsh-goofish-mcp

### DIFF
--- a/catalog/plugins/zhengjy01--dsh-goofish-mcp.json
+++ b/catalog/plugins/zhengjy01--dsh-goofish-mcp.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zhengjy01/dsh-goofish-mcp",
+  "name": "dsh-goofish-mcp",
+  "repository": "https://github.com/zhengjy01/dsh-goofish-mcp",
+  "category": "tools",
+  "description": {
+    "en": "Xianyu (Goofish 闲鱼) read-only monitoring for DeepSeek Harness: drives the goofish-cli MCP server and exposes read-only tools (search, item detail, listings, chat history, category) with all write actions filtered out.",
+    "zh": "DeepSeek Harness 的闲鱼只读监控：驱动 goofish-cli MCP 服务器，暴露搜索 / 商品详情 / 在售列表 / 会话历史 / 类目识别等只读工具，写操作一律过滤。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
## 新增插件：`zhengjy01/dsh-goofish-mcp`

本 PR 只新增一个 catalog 文件：`catalog/plugins/zhengjy01--dsh-goofish-mcp.json`。

### 插件用途

驱动 goofish-cli MCP 服务器，把闲鱼（Goofish）数据以只读工具形式接入：搜索商品、商品详情、在售列表、会话历史、类目识别等；发布 / 下架 / 发消息等写操作一律不注册。

### 基本信息

| 字段 | 值 |
| --- | --- |
| id | `zhengjy01/dsh-goofish-mcp` |
| 仓库 | https://github.com/zhengjy01/dsh-goofish-mcp |
| npm 包 | [`dsh-goofish-mcp`](https://www.npmjs.com/package/dsh-goofish-mcp) |
| category | `tools` |
| added | `2026-09-11` |

### 英文说明

Xianyu (Goofish 闲鱼) read-only monitoring for DeepSeek Harness: drives the goofish-cli MCP server and exposes read-only tools (search, item detail, listings, chat history, category) with all write actions filtered out.

### 中文说明

DeepSeek Harness 的闲鱼只读监控：驱动 goofish-cli MCP 服务器，暴露搜索 / 商品详情 / 在售列表 / 会话历史 / 类目识别等只读工具，写操作一律过滤。

已确认仓库根目录存在 `package.json` 且声明了 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件存在于同一 revision。
