### PR TITLE
catalog: add zhengjy01/dsh-npm

### DIFF
--- a/catalog/plugins/zhengjy01--dsh-npm.json
+++ b/catalog/plugins/zhengjy01--dsh-npm.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zhengjy01/dsh-npm",
+  "name": "dsh-npm",
+  "repository": "https://github.com/zhengjy01/dsh-npm",
+  "category": "dev",
+  "description": {
+    "en": "NPM registry management for DeepSeek Harness: query package info, list versions, search packages, and publish/deprecate with optional token injection, plus a web settings panel.",
+    "zh": "DeepSeek Harness 的 NPM 包管理：查询包信息 / 版本列表 / 搜索包，并用本机或注入的 token 发布与弃用，附 Web 设置面板。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
## 新增插件：`zhengjy01/dsh-npm`

本 PR 只新增一个 catalog 文件：`catalog/plugins/zhengjy01--dsh-npm.json`。

### 插件用途

在 DSH 里直接管理 npm：查询包信息、列出版本、搜索包，并使用本机 ~/.npmrc 凭据或注入的 token 执行发布与弃用，附 Web 设置面板。

### 基本信息

| 字段 | 值 |
| --- | --- |
| id | `zhengjy01/dsh-npm` |
| 仓库 | https://github.com/zhengjy01/dsh-npm |
| npm 包 | [`dsh-npm`](https://www.npmjs.com/package/dsh-npm) |
| category | `dev` |
| added | `2026-09-11` |

### 英文说明

NPM registry management for DeepSeek Harness: query package info, list versions, search packages, and publish/deprecate with optional token injection, plus a web settings panel.

### 中文说明

DeepSeek Harness 的 NPM 包管理：查询包信息 / 版本列表 / 搜索包，并用本机或注入的 token 发布与弃用，附 Web 设置面板。

已确认仓库根目录存在 `package.json` 且声明了 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件存在于同一 revision。
