### PR TITLE
catalog: add zhengjy01/dsh-backup-migrator

### DIFF
--- a/catalog/plugins/zhengjy01--dsh-backup-migrator.json
+++ b/catalog/plugins/zhengjy01--dsh-backup-migrator.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zhengjy01/dsh-backup-migrator",
+  "name": "dsh-backup-migrator",
+  "repository": "https://github.com/zhengjy01/dsh-backup-migrator",
+  "category": "dev",
+  "description": {
+    "en": "Plugin environment backup and migration for DeepSeek Harness: backs up every profile's plugin list, plugin configs and local-source plugin tarballs into a git repo, and restores them on a new machine.",
+    "zh": "DeepSeek Harness 插件环境备份与迁移：把各 profile 的插件清单、插件配置与本地源插件打包进 git 仓库，换机一键恢复。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
## 新增插件：`zhengjy01/dsh-backup-migrator`

本 PR 只新增一个 catalog 文件：`catalog/plugins/zhengjy01--dsh-backup-migrator.json`。

### 插件用途

把各 profile 的插件清单（dependencies + bundles 加载顺序）、插件配置（~/.dsh/dsh-*.json）与本地源码插件（自动打包为 tgz）备份进一个 git 仓库并 push；换机 clone 后一键还原，解决插件环境迁移问题。

### 基本信息

| 字段 | 值 |
| --- | --- |
| id | `zhengjy01/dsh-backup-migrator` |
| 仓库 | https://github.com/zhengjy01/dsh-backup-migrator |
| npm 包 | [`dsh-backup-migrator`](https://www.npmjs.com/package/dsh-backup-migrator) |
| category | `dev` |
| added | `2026-09-11` |

### 英文说明

Plugin environment backup and migration for DeepSeek Harness: backs up every profile's plugin list, plugin configs and local-source plugin tarballs into a git repo, and restores them on a new machine.

### 中文说明

DeepSeek Harness 插件环境备份与迁移：把各 profile 的插件清单、插件配置与本地源插件打包进 git 仓库，换机一键恢复。

已确认仓库根目录存在 `package.json` 且声明了 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件存在于同一 revision。
