### PR TITLE
catalog: add zhengjy01/dsh-feishu-mcp

### DIFF
--- a/catalog/plugins/zhengjy01--dsh-feishu-mcp.json
+++ b/catalog/plugins/zhengjy01--dsh-feishu-mcp.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zhengjy01/dsh-feishu-mcp",
+  "name": "dsh-feishu-mcp",
+  "repository": "https://github.com/zhengjy01/dsh-feishu-mcp",
+  "category": "notify",
+  "description": {
+    "en": "Feishu (Lark) OpenAPI MCP connection for DeepSeek Harness: bridges the official @larksuiteoapi/lark-mcp server, exposing IM, Bitable, Docs, Calendar and Drive APIs as mcp__feishu__* tools with OAuth user-token support.",
+    "zh": "DeepSeek Harness 的飞书（Lark）OpenAPI MCP 连接：桥接官方 @larksuiteoapi/lark-mcp，把 IM / 多维表格 / 云文档 / 日历 / 云盘 API 暴露为 mcp__feishu__* 工具，支持用户令牌 OAuth。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
## 新增插件：`zhengjy01/dsh-feishu-mcp`

本 PR 只新增一个 catalog 文件：`catalog/plugins/zhengjy01--dsh-feishu-mcp.json`。

### 插件用途

桥接飞书官方 @larksuiteoapi/lark-mcp 服务器，把 IM 消息、多维表格（Bitable）、云文档、日历、云盘等 OpenAPI 暴露为 mcp__feishu__* 工具，并支持用户令牌 OAuth 授权访问私有资源。

### 基本信息

| 字段 | 值 |
| --- | --- |
| id | `zhengjy01/dsh-feishu-mcp` |
| 仓库 | https://github.com/zhengjy01/dsh-feishu-mcp |
| npm 包 | [`dsh-feishu-mcp`](https://www.npmjs.com/package/dsh-feishu-mcp) |
| category | `notify` |
| added | `2026-09-11` |

### 英文说明

Feishu (Lark) OpenAPI MCP connection for DeepSeek Harness: bridges the official @larksuiteoapi/lark-mcp server, exposing IM, Bitable, Docs, Calendar and Drive APIs as mcp__feishu__* tools with OAuth user-token support.

### 中文说明

DeepSeek Harness 的飞书（Lark）OpenAPI MCP 连接：桥接官方 @larksuiteoapi/lark-mcp，把 IM / 多维表格 / 云文档 / 日历 / 云盘 API 暴露为 mcp__feishu__* 工具，支持用户令牌 OAuth。

已确认仓库根目录存在 `package.json` 且声明了 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件存在于同一 revision。
