### PR TITLE
catalog: add zhengjy01/dsh-aliyun-mcp

### DIFF
--- a/catalog/plugins/zhengjy01--dsh-aliyun-mcp.json
+++ b/catalog/plugins/zhengjy01--dsh-aliyun-mcp.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zhengjy01/dsh-aliyun-mcp",
+  "name": "dsh-aliyun-mcp",
+  "repository": "https://github.com/zhengjy01/dsh-aliyun-mcp",
+  "category": "dev",
+  "description": {
+    "en": "Alibaba Cloud OpenAPI MCP connection for DeepSeek Harness: static-credential mode through the official OpenAPI MCP proxy, exposing ECS / OSS / DNS / Function Compute APIs as mcp__aliyun__* tools.",
+    "zh": "DeepSeek Harness 的阿里云 OpenAPI MCP 连接：静态凭证 + 官方 MCP Proxy，把 ECS / OSS / 域名 / DNS / 函数计算等 OpenAPI 暴露为 mcp__aliyun__* 工具。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
## 新增插件：`zhengjy01/dsh-aliyun-mcp`

本 PR 只新增一个 catalog 文件：`catalog/plugins/zhengjy01--dsh-aliyun-mcp.json`。

### 插件用途

通过官方 OpenAPI MCP Proxy 接入阿里云，使用静态 AccessKey（推荐 RAM 子账号）调用 ECS / OSS / 域名 / DNS / 函数计算等 OpenAPI，暴露为 mcp__aliyun__* 工具。

### 基本信息

| 字段 | 值 |
| --- | --- |
| id | `zhengjy01/dsh-aliyun-mcp` |
| 仓库 | https://github.com/zhengjy01/dsh-aliyun-mcp |
| npm 包 | [`dsh-aliyun-mcp`](https://www.npmjs.com/package/dsh-aliyun-mcp) |
| category | `dev` |
| added | `2026-09-11` |

### 英文说明

Alibaba Cloud OpenAPI MCP connection for DeepSeek Harness: static-credential mode through the official OpenAPI MCP proxy, exposing ECS / OSS / DNS / Function Compute APIs as mcp__aliyun__* tools.

### 中文说明

DeepSeek Harness 的阿里云 OpenAPI MCP 连接：静态凭证 + 官方 MCP Proxy，把 ECS / OSS / 域名 / DNS / 函数计算等 OpenAPI 暴露为 mcp__aliyun__* 工具。

已确认仓库根目录存在 `package.json` 且声明了 `dsh.bundle.patch: ./cordis.patch.yml`，patch 文件存在于同一 revision。
