### PR TITLE
catalog: add nagatoquin33/dsh-villager-hmm

### DIFF
--- a/catalog/plugins/nagatoquin33--dsh-villager-hmm.json
+++ b/catalog/plugins/nagatoquin33--dsh-villager-hmm.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "nagatoquin33/dsh-villager-hmm",
+  "name": "dsh-villager-hmm",
+  "repository": "https://github.com/nagatoquin33/dsh-villager-hmm",
+  "category": "fun",
+  "description": {
+    "en": "Plays a Minecraft villager sound each time a hmm-like interjection appears in the model reasoning stream or reply. Ships a draggable panel showing the hit count, with a pause toggle and an editable matcher.",
+    "zh": "模型的思维链或回复里出现 hmm、嗯、唔 等哼声时，播放一次 Minecraft 村民音效。附带可拖动面板，显示命中次数，可暂停监听，并可编辑匹配式。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
## 摘要

将 [`nagatoquin33/dsh-villager-hmm`](https://github.com/nagatoquin33/dsh-villager-hmm) 添加到 DeepSeek Harness 插件目录。

## 插件验证

- Manifest：`package.json`
- Bundle patch：`cordis.patch.yml`
- 测试命令：`npm test`、`npm run test:boot`、`node test/assert-tarball.mjs`
- 测试结果：hermetic 套件 38 项全部通过（含逐字符流扫描、路由、面板渲染与真实点击回放、双语字典一致性、发布断言）；boot 套件 8 项全部通过（在真实 cordis Context 中挂载宿主半，覆盖 webServer 缺失、register 抛错、畸形 URL、未知 chunk/frame 类型、无未捕获 rejection）；tarball 断言为 code-only。GitHub Actions CI 在 ubuntu-latest（Node 22、24）与 windows-latest（Node 22）全部通过。
- 安装可用性：npm 上的 `dsh-villager-hmm@1.0.2`，latest manifest 声明 `dsh.bundle`，且由 GitHub Actions 经 OIDC 发布并附带 SLSA provenance。

## 目录提交确认

- [x] 本 PR 只新增一个 `catalog/plugins/*.json` 文件，不包含其他改动
- [x] 插件仓库声明了 `dsh.bundle.patch`，并已提交引用的补丁文件
- [x] 作者已经测试插件行为和兼容性
- [x] 插件仓库已添加 `dsh-plugin` topic
- [x] 中英文简介中性且准确
- [x] 我理解检查失败时 PR 会保持打开以便修复；非草稿 PR 通过后会自动合并，合并后由 CI 自动同步到网站目录与 README，且收录不代表对插件行为、安全性或质量的背书
