### PR TITLE
Add hutao562/dsh-remote-dsh to the catalog

### DIFF
--- a/catalog/plugins/hutao562--dsh-remote-dsh.json
+++ b/catalog/plugins/hutao562--dsh-remote-dsh.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "hutao562/dsh-remote-dsh",
+  "name": "dsh-remote-dsh",
+  "repository": "https://github.com/hutao562/dsh-remote-dsh",
+  "category": "ui",
+  "description": {
+    "en": "Adds a row at the top of the sidebar that switches the whole Web GUI to another DSH host reached over a loopback port, and shows that host's session state on the row (running, unread activity, or waiting for your answer).",
+    "zh": "在侧边栏顶部加一行，点击后整页切换成另一台 DSH 主机的 Web GUI（通过回环端口访问），并在该行显示那台主机的会话状态（运行中、有新活动、正等你回答）。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
Adds one catalog entry for [`hutao562/dsh-remote-dsh`](https://github.com/hutao562/dsh-remote-dsh).

**What it does:** adds a row at the top of the sidebar; clicking it switches the whole Web GUI to another DSH host reached over a loopback port (an `ssh -L` tunnel, or an FRP `stcp`/`xtcp` + `frpc` visitor forward), and the row carries that host's session state — blue while it runs, green for activity since you last looked, amber while it waits on an approval or question from you.

**Submission checks:**

- `package.json` declares `dsh.bundle.patch: ./cordis.patch.yml`, and `cordis.patch.yml` is committed at the repository root.
- The repository carries the `dsh-plugin` GitHub topic.
- This PR adds exactly one file, `catalog/plugins/hutao562--dsh-remote-dsh.json`; nothing outside `catalog/plugins/` is touched.
- Published on npm as [`dsh-remote-dsh`](https://www.npmjs.com/package/dsh-remote-dsh) (0.1.1), so the store can show a real install command. The latest commits after that publish are docs-only.

Install command: `dsh plugin --profile web add dsh-remote-dsh` (npm), or `dsh plugin --profile web add github:hutao562/dsh-remote-dsh` for `main`.
