### PR TITLE
Add zuoyunlai/lunheng-article-pipeline-dsh to the catalog

### DIFF
--- a/catalog/plugins/zuoyunlai--lunheng-article-pipeline-dsh.json
+++ b/catalog/plugins/zuoyunlai--lunheng-article-pipeline-dsh.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "zuoyunlai/lunheng-article-pipeline-dsh",
+  "name": "lunheng-article-pipeline-dsh",
+  "repository": "https://github.com/zuoyunlai/lunheng-article-pipeline-dsh",
+  "category": "workflow",
+  "description": {
+    "en": "Registers one long-form writing skill that runs a 9-role pipeline across 6 phases — T1 literature / T2 data / T3 case retrieval, T4 analysis, T5 drafting, T6 critique, T7 audit, T8 final check (run by the coordinator), T9 peer review — with 4 human checkpoints, triangular evidence verification, a 23-check mechanical final gate, a G0-G14 audit, and peer-review scoring with journal matching. Installs with `dsh plugin add lunheng-article-pipeline`.",
+    "zh": "注册一个深度长文写作技能：9 个独立角色跨 6 个阶段（T1 文献 / T2 数据 / T3 案例检索、T4 分析、T5 写作、T6 批判、T7 审计、T8 终检（主控亲执行）、T9 同行评审），含 4 个人在环节点、三角验证、M 门 23 项机械终检、G0-G14 独立审计与审稿评分/期刊匹配。`dsh plugin add lunheng-article-pipeline` 即装。"
+  },
+  "added": "2026-09-11"
+}


### PR DESCRIPTION
Adds one catalog entry per `catalog/README` conventions (only this file is touched):

`catalog/plugins/zuoyunlai--lunheng-article-pipeline-dsh.json` — category `workflow`.

Install path, so the gates can be checked mechanically: `package.json` declares `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }` and the patch file is committed at the repo root; the repo carries the `dsh-plugin` topic; the package is published on npm, so `dsh plugin add lunheng-article-pipeline` works (verified against `@deepseek-ai/dsh` `0.1.2-rc.1`: install into a fresh profile → `--dump-config` shows the bundle layer, the package's own loader row and its three tiered `@deepseek-ai/dsh-tool-subagent` rows → the installed copy's entry registers the skill).

The description states only what the package ships: 9 independent roles (T1 literature, T2 data, T3 case, T4 analysis, T5 drafting, T6 critique, T7 audit, T8 final check run by the coordinator, T9 peer review) across 6 phases, 4 human checkpoints, a 23-check mechanical final gate (M-Form 11 + M-Exist 10 + M-Integrity 2), a G0-G14 audit, and peer-review scoring with journal matching. No superlatives.
