### PR TITLE
Add cjm-m/dsh-paste-code-block to catalog

### DIFF
--- a/catalog/plugins/cjm-m--dsh-paste-code-block.json
+++ b/catalog/plugins/cjm-m--dsh-paste-code-block.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "cjm-m/dsh-paste-code-block",
+  "name": "dsh-paste-code-block",
+  "repository": "https://github.com/cjm-m/dsh-paste-code-block",
+  "category": "ui",
+  "description": {
+    "en": "Renders long text and code pasted into the DSH Web composer as collapsible cards with language tags and independent line numbering; the original fenced code block is restored when the message is sent.",
+    "zh": "将粘贴到 DSH Web 输入框的长文本或代码渲染为可折叠卡片，带语言标签与独立行号编号，发送消息时自动还原为围栏代码块。"
+  },
+  "added": "2026-09-12"
+}


### PR DESCRIPTION
Adds one new catalog entry: `catalog/plugins/cjm-m--dsh-paste-code-block.json` for `cjm-m/dsh-paste-code-block`.

- `package.json` (repo root) declares `dsh.bundle.patch: "./cordis.patch.yml"`; the patch file is committed on the default branch.
- Repository has the `dsh-plugin` topic.
- Installable: published on npm as `dsh-paste-code-block` (latest 0.1.1) with its `dsh.bundle` declaration.
- Only one file under `catalog/plugins/` is touched; no README/workflow/script changes.

Checked locally against the repository's own review logic (`validateCatalogEntry`, `reviewRepository`, `validateSubmissionChanges`): all pass, verdict `auto-merge`.