### PR TITLE
Add new-Beginner/dsh-thought-fold to catalog

### DIFF
--- a/catalog/plugins/new-beginner--dsh-thought-fold.json
+++ b/catalog/plugins/new-beginner--dsh-thought-fold.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../schema/plugin.schema.json",
+  "id": "new-Beginner/dsh-thought-fold",
+  "name": "dsh-thought-fold",
+  "repository": "https://github.com/new-Beginner/dsh-thought-fold",
+  "category": "ui",
+  "description": {
+    "en": "Codex-style progress reporting and native turn-process compact transcript folding enhancement for DeepSeek Harness.",
+    "zh": "DeepSeek Harness 的 Codex 风格执行进度规范与原生会话过程折叠增强插件。"
+  },
+  "added": "2026-09-12"
+}


### PR DESCRIPTION
Adds one new catalog entry: catalog/plugins/new-beginner--dsh-thought-fold.json for 
ew-Beginner/dsh-thought-fold.

- package.json (repo root) declares dsh.bundle.patch: "./cordis.patch.yml"; the patch file is committed on the default branch.
- Repository has the dsh-plugin topic.
- Category: ui.
- Only one file under catalog/plugins/ is touched; no README/workflow/script changes.

Checked locally against schema and catalog guidelines: valid JSON schema, factual descriptions in en/zh, proper slugified filename.